### PR TITLE
splunk_monitor 'path/to/thing/'

### DIFF
--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -15,13 +15,11 @@
 # limitations under the License.
 #
 require 'pathname'
-require 'chef/provider/lwrp_base'
 require_relative './helpers.rb'
-require 'chef/mixin/shell_out'
-include Chef::Mixin::ShellOut
+require_relative './splunk_base_provider.rb'
 
 # Creates a provider for the splunk_app resource.
-class Chef::Provider::SplunkApp < Chef::Provider::LWRPBase
+class Chef::Provider::SplunkApp < Chef::Provider::SplunkBaseProvider
   use_inline_resources if defined?(:use_inline_resources)
 
   def whyrun_supported?
@@ -134,14 +132,6 @@ class Chef::Provider::SplunkApp < Chef::Provider::LWRPBase
 
   def app_installed?
     ::File.exists?("#{app_dir}/default/app.conf")
-  end
-
-  def splunk_service
-    service 'splunk' do
-      action :nothing
-      supports :status => true, :restart => true
-      provider Chef::Provider::Service::Init
-    end
   end
 
   def install_dependencies

--- a/libraries/splunk_base_provider.rb
+++ b/libraries/splunk_base_provider.rb
@@ -1,0 +1,34 @@
+#
+# Author: Jameson Lee <jameson@hey.co>
+# Copyright (c) 2014, Hey, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Largely based on chef-splunk/libraries/splunk_app_provider.rb
+#
+require 'chef/provider/lwrp_base'
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+# Creates a provider for the splunk_app resource.
+class Chef::Provider::SplunkBaseProvider < Chef::Provider::LWRPBase
+
+  def splunk_service
+    service 'splunk' do
+      action :nothing
+      supports :status => true, :restart => true
+      provider Chef::Provider::Service::Init
+    end
+  end
+
+end

--- a/libraries/splunk_monitor_provider.rb
+++ b/libraries/splunk_monitor_provider.rb
@@ -1,0 +1,55 @@
+#
+# Author: Jameson Lee <jameson@hey.co>
+# Copyright (c) 2014, Hey, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Largely based on chef-splunk/libraries/splunk_app_provider.rb
+#
+require_relative './splunk_base_provider.rb'
+require_relative './helpers.rb'
+
+# Creates a provider for the splunk_app resource.
+class Chef::Provider::SplunkMonitor < Chef::Provider::SplunkBaseProvider
+  use_inline_resources if defined?(:use_inline_resources)
+
+  def whyrun_supported?
+    true
+  end
+
+  action :add do
+    splunk_service
+    unless in_list_monitor
+      execute "splunk-add-monitor-#{new_resource.source}" do
+        command "#{splunk_cmd} add monitor #{new_resource.source} -auth #{splunk_auth(new_resource.splunk_auth)}"
+      end
+    end
+  end
+
+  action :remove do
+    splunk_service
+    if in_list_monitor
+      execute "splunk-remove-monitor-#{new_resource.source}" do
+        command "#{splunk_cmd} remove monitor #{new_resource.source} -auth #{splunk_auth(new_resource.splunk_auth)}"
+      end
+    end
+  end
+
+  def in_list_monitor
+    # grep for source name
+    cmd = "#{splunk_cmd} list monitor -auth #{splunk_auth(new_resource.splunk_auth)} | grep '^\\s*#{new_resource.source}$'"
+    result = shell_out(cmd)
+    (result.exitstatus == 0) ? true: false
+  end
+
+end

--- a/libraries/splunk_monitor_resource.rb
+++ b/libraries/splunk_monitor_resource.rb
@@ -1,0 +1,31 @@
+#
+# Author: Jameson Lee <jameson@hey.co>
+# Copyright (c) 2014, Hey, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Largely based on chef-splunk's splunk_app_resource
+#
+require 'chef/resource/lwrp_base'
+
+# Creates a splunk_app resource.
+class Chef::Resource::SplunkMonitor < Chef::Resource::LWRPBase
+  self.resource_name = 'splunk_monitor'
+
+  # Actions correspond to splunk commands pertaining to apps.
+  actions :add, :remove
+  default_action :add
+
+  attribute :source, :kind_of => String, :name_attribute => true
+  attribute :splunk_auth, :kind_of => String, :required => true
+end


### PR DESCRIPTION
I wrote a library for the splunk monitor resource.
thoughts? (yes, it's missing tests)

it introduces ability to add/remove monitor and also checks if the command will explode using list and grep

```
splunk_monitor '/var/log/syslog' do
  action: add
end

# explodes
splunk_monitor '/somewhere/that/dun/exist/'

# removes from monitor
splunk_monitor '/var/log/syslog' do
  action :remove
end
```