### PR TITLE
bumping default version of splunk from 6.0.3 to 6.1.3

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,6 +60,6 @@ when 'debian'
     default['splunk']['server']['url'] = 'http://download.splunk.com/releases/6.1.3/splunk/linux/splunk-6.1.3-220630-linux-2.6-intel.deb'
   end
 when 'omnios'
-  default['splunk']['forwarder']['url'] = 'http://download.splunk.com/releases/6.1.3/universalforwarder/solaris/splunkforwarder-6.1.3-220630-SunOS-x86_64.tar.Z'
+  default['splunk']['forwarder']['url'] = 'http://download.splunk.com/releases/6.1.3/universalforwarder/solaris/splunkforwarder-6.1.3-220630-solaris-10-intel.pkg.Z'
   default['splunk']['server']['url'] = 'http://download.splunk.com/releases/6.1.3/splunk/solaris/splunk-6.1.3-220630-solaris-10-intel.pkg.Z'
 end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -24,6 +24,10 @@ splunk_app 'bistro-remote-file' do
   remote_file 'https://github.com/ampledata/bistro/archive/1.0.2.tar.gz'
   splunk_auth 'admin:notarealpassword'
   templates ['inputs.conf']
+  if node['platform_family'] == 'omnios'
+  app_dependencies ['ruby-19']
+  else
   app_dependencies ['ruby']
+  end
   action :install
 end


### PR DESCRIPTION
@jtimberman Sir, I think to upgrade our splunk servers we'll want to run the chef-splunk::upgrade recipe per usual, and before removing upgrade.rb we'll want to make sure to update chef-splunk/attributes/default.rb to bump up all the splunk software urls to the desired version.  Thats what this PR is for.  I'm curious after merging this, should I tag 1.2.1 and update our pinnings, or should I re-apply the tag for 1.2.0?

Optionally we could keep chef-splunk at 6.0.3 and add these urls to our role:splunk-server and so forth as override attributes, but I figure we do want to pull in updates on the base chef-splunk.

Mostly want to confirm the tag thing, then I'll go merge and deploy this to preprod.

Probably will also want to re-run the kitchen server/client tests today as well (I did test all the updated urls to confirm they don't 404).  Think I got em right.
