### PR TITLE
Support any type of input for inputs.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,12 +39,6 @@ default['splunk']['ssl_options'] = {
 
 # Add key value pairs to this to add configuration pairs to the output.conf file
 # 'sslCertPath' => '$SPLUNK_HOME/etc/certs/cert.pem'
-default['splunk']['outputs_conf'] = {
-  'forwardedindex.0.whitelist' => '.*',
-  'forwardedindex.1.blacklist' => '_.*',
-  'forwardedindex.2.whitelist' => '_audit',
-  'forwardedindex.filter.disable' => 'false'
-}
 
 # Add a host name if you need inputs.conf file to be configured
 # Note: if host is empty the inputs.conf template will not be used.
@@ -58,6 +52,22 @@ default['splunk']['inputs_conf']['ports'] = []
 default['splunk']['user']['home'] = '/opt/splunk' if node['splunk']['is_server']
 
 default['splunk']['server']['runasroot'] = true
+
+default['splunk']['output_groups'] = {
+  'default' => {
+      'servers' => [{
+          'ipaddress' => '127.0.0.1',
+          'port' => node['splunk']['receiver_port'],
+        }],
+     'attributes' => {
+          'forwardedindex.0.whitelist' => '.*',
+          'forwardedindex.1.blacklist' => '_.*',
+          'forwardedindex.2.whitelist' => '_audit',
+          'forwardedindex.filter.disable' => 'false'
+        }
+
+    },
+}
 
 case node['platform_family']
 when 'rhel'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -35,6 +35,13 @@ else
   end
 end
 
+servers_hash = []
+for s in splunk_servers
+  servers_hash.push({'ipaddress' => s, 'port' => node['splunk']['receiver_port']})
+end
+
+node.set['splunk']['output_groups']['default']['servers'] = servers_hash
+
 # ensure that the splunk service resource is available without cloning
 # the resource (CHEF-3694). this is so the later notification works,
 # especially when using chefspec to run this cookbook's specs.
@@ -53,7 +60,7 @@ end
 template "#{splunk_dir}/etc/system/local/outputs.conf" do
   source 'outputs.conf.erb'
   mode 0644
-  variables :splunk_servers => splunk_servers, :outputs_conf => node['splunk']['outputs_conf']
+  variables :outputs => node['splunk']['output_groups']
   notifies :restart, 'service[splunk]'
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -37,7 +37,7 @@ end
 
 servers_hash = []
 for s in splunk_servers
-  servers_hash.push({'ipaddress' => s, 'port' => node['splunk']['receiver_port']})
+  servers_hash.push({'ipaddress' => s['ipaddress'], 'port' => s['splunk']['receiver_port']})
 end
 
 node.set['splunk']['output_groups']['default']['servers'] = servers_hash

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -31,6 +31,10 @@ splunk_servers = search( # ~FC003
   |a, b| a.name <=> b.name
 end
 
+if splunk_servers.empty?
+  splunk_servers = node['splunk']['splunk_servers']
+end
+
 # ensure that the splunk service resource is available without cloning
 # the resource (CHEF-3694). this is so the later notification works,
 # especially when using chefspec to run this cookbook's specs.

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -73,4 +73,4 @@ template "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/limits.conf" d
 end
 
 include_recipe 'chef-splunk::service'
-include_recipe 'chef-splunk::setup_auth'
+#include_recipe 'chef-splunk::setup_auth'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -24,15 +24,15 @@
 include_recipe 'chef-splunk::user'
 include_recipe 'chef-splunk::install_forwarder'
 
-splunk_servers = search( # ~FC003
-  :node,
-  "splunk_is_server:true AND chef_environment:#{node.chef_environment}"
-).sort! do
-  |a, b| a.name <=> b.name
-end
-
-if splunk_servers.empty?
+if node['splunk']['splunk_servers']
   splunk_servers = node['splunk']['splunk_servers']
+else
+  splunk_servers = search( # ~FC003
+    :node,
+    "splunk_is_server:true AND chef_environment:#{node.chef_environment}"
+  ).sort! do
+    |a, b| a.name <=> b.name
+  end
 end
 
 # ensure that the splunk service resource is available without cloning

--- a/templates/default/inputs.conf.erb
+++ b/templates/default/inputs.conf.erb
@@ -10,7 +10,7 @@ host = <%= @inputs_conf['host'] %>
 
 <% @input_conf['inputs'].sort.each do |inputname| -%>
 [<%= inputname -%>]
-  <% @input_hash[inputname].sort.each do |key,value| -%>
+<% @input_conf['inputs'][inputname].sort.each do |key,value| -%>
   <%= key -%> = <%= value %>
   <% end %>
 <% end %>

--- a/templates/default/inputs.conf.erb
+++ b/templates/default/inputs.conf.erb
@@ -7,3 +7,10 @@ host = <%= @inputs_conf['host'] %>
 <%= name %> = <%= value %>
   <% end -%>
 <% end -%>
+
+<% @input_conf['inputs'].sort.each do |inputname| -%>
+[<%= inputname -%>]
+  <% @input_hash[inputname].sort.each do |key,value| -%>
+  <%= key -%> = <%= value %>
+  <% end %>
+<% end %>

--- a/templates/default/inputs.conf.erb
+++ b/templates/default/inputs.conf.erb
@@ -8,9 +8,9 @@ host = <%= @inputs_conf['host'] %>
   <% end -%>
 <% end -%>
 
-<% @input_conf['inputs'].sort.each do |inputname| -%>
+<% @inputs_conf['inputs'].keys.sort.each do |inputname| -%>
 [<%= inputname -%>]
-<% @input_conf['inputs'][inputname].sort.each do |key,value| -%>
+<% @inputs_conf['inputs'][inputname].sort.each do |key,value| -%>
   <%= key -%> = <%= value %>
   <% end %>
 <% end %>

--- a/templates/default/outputs.conf.erb
+++ b/templates/default/outputs.conf.erb
@@ -1,9 +1,12 @@
 [tcpout]
-defaultGroup = splunk_indexers_<%= node['splunk']['receiver_port'] %>
+defaultGroup = default
 disabled=false
 
-[tcpout:splunk_indexers_<%= node['splunk']['receiver_port'] %>]
-server=<% @splunk_servers.map do |s| -%><%= s['ipaddress'] %>:<%= s['splunk']['receiver_port'] %> <% end.join(', ') -%>
-<% @outputs_conf.each_pair do |name, value| -%>
+<% @outputs.each_pair do |name, output| -%>
+[tcpout:<%= name %>]
+server=<% output['servers'].map do |s| -%><%= s['ipaddress'] %>:<%= s['port'] %> <% end.join(', ') -%>
+<% output['attributes'].each_pair do |name, value| -%>
 <%= name %> = <%= value %>
+<% end -%>
+
 <% end -%>

--- a/templates/default/outputs.conf.erb
+++ b/templates/default/outputs.conf.erb
@@ -4,7 +4,7 @@ disabled=false
 
 <% @outputs.each_pair do |name, output| -%>
 [tcpout:<%= name %>]
-server=<% output['servers'].map do |s| -%><%= s['ipaddress'] %>:<%= s['port'] %> <% end.join(', ') -%>
+server=<%= output['servers'].map { |s| "#{s['ipaddress']}:#{s['port']}" }.join(',') %>
 <% output['attributes'].each_pair do |name, value| -%>
 <%= name %> = <%= value %>
 <% end -%>


### PR DESCRIPTION
You can only add tcp inputs with the current implementation. With this patch you can define a structure like the example one and create any type of input supported by splunk.

```javascript
default['splunk']['inputs_conf']['inputs'] = {
  'monitor:///var/log/syslog' => {
    'sourcetype' => 'syslog',
    'disabled'   => 'false',
    'index'      => node['splunk']['index']
  }
}
```

This patch also add the ability to define the splunk server using an attribute if you don't have a splunk server in your chef database.
```javascript
default['splunk']['splunk_servers'] = [
  {
    'ipaddress' => '1.2.3.4',
    'splunk'    => {'receiver_port' => 9997}
  }
]
```