### PR TITLE
Fix init.d script to use the configured run-as user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Special attributes for managing the Splunk user:
   chosen and doesn't conflict with anything on the supported platforms
   (see list above). It is within the `system` UID range on Linux
   systems.
+- `gid`: the numeric GID. The default, `396` is an integer arbitrarily
+  chosen and doesn't conflict with anything on the supported platforms
+  (see list above). It is within the `system` GID range on Linux
+  systems.
 
 * `node['splunk']['server']['runasroot']`: if runasroot is true (which is the splunk upstream package default) then the splunk server runs as root.  If runasroot is false modify the init script to run as the `node['splunk']['user']`.  This does not apply to the splunk client as they may need root permissions to read logfiles.  NOTE1: you may also need to change `node['splunk']['web_port']` on a splunk server to run on a port >1024 if you don't run as root (splunk user cannot bind to privelaged ports).  NOTE2: If you want to switch from root to the splunk user or vice versa on an existing install, please stop the splunk service first before changing the runasroot boolean value.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,8 @@ default['splunk']['user'] = {
   'comment'  => 'Splunk Server',
   'home'     => '/opt/splunkforwarder',
   'shell'    => '/bin/bash',
-  'uid'      => 396
+  'uid'      => 396,
+  'gid'      => 396
 }
 
 default['splunk']['ssl_options'] = {

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -80,7 +80,8 @@ template '/etc/init.d/splunk' do
   mode 0700
   variables(
     :splunkdir => splunk_dir,
-    :runasroot => node['splunk']['server']['runasroot']
+    :runasroot => node['splunk']['server']['runasroot'],
+    :splunkuser => myuser
   )
 end
 

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -19,7 +19,7 @@
 #
 
 group node['splunk']['user']['username'] do
-  gid node['splunk']['user']['uid'].to_i # CHEF-4927
+  gid node['splunk']['user']['gid'].to_i # CHEF-4927
   system true if %w(linux).include?(node['os'])
 end
 

--- a/templates/default/splunk-init.erb
+++ b/templates/default/splunk-init.erb
@@ -21,7 +21,7 @@ splunk_start() {
   <% if @runasroot %>
   "<%= @splunkdir %>/bin/splunk" start --no-prompt --answer-yes
   <% else %>
-  /bin/su - splunk -c "\"<%= @splunkdir %>/bin/splunk\" start --no-prompt --answer-yes"
+  /bin/su - <%= @splunkuser %> -c "\"<%= @splunkdir %>/bin/splunk\" start --no-prompt --answer-yes"
   <% end %>
   RETVAL=$?
 }
@@ -30,7 +30,7 @@ splunk_stop() {
   <% if @runasroot %>
   "<%= @splunkdir %>/bin/splunk" stop 
   <% else %>
-  /bin/su - splunk -c "\"<%= @splunkdir %>/bin/splunk\" stop "
+  /bin/su - <%= @splunkuser %> -c "\"<%= @splunkdir %>/bin/splunk\" stop "
   <% end %>
   RETVAL=$?
 }
@@ -39,7 +39,7 @@ splunk_restart() {
   <% if @runasroot %>
   "<%= @splunkdir %>/bin/splunk" restart 
   <% else %>
-  /bin/su - splunk -c "\"<%= @splunkdir %>/bin/splunk\" restart "
+  /bin/su - <%= @splunkuser %> -c "\"<%= @splunkdir %>/bin/splunk\" restart "
   <% end %>
   RETVAL=$?
 }
@@ -48,7 +48,7 @@ splunk_status() {
   <% if @runasroot %>
   "<%= @splunkdir %>/bin/splunk" status 
   <% else %>
-  /bin/su - splunk -c "\"<%= @splunkdir %>/bin/splunk\" status "
+  /bin/su - <%= @splunkuser %> -c "\"<%= @splunkdir %>/bin/splunk\" status "
   <% end %>
   RETVAL=$?
 }


### PR DESCRIPTION
I noticed this when attempting to run the Splunk service as a user other than `splunk`. This commit replaces the hard-coded user value with a template parameter provided by the service recipe.
