### PR TITLE
Use declare_resource for local package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ cookbook doesn't support installing from networked package managers
 
 ## Requirements
 
+Chef 11.10.0+ for `declare_resource`.
+
 ### Platforms
 
 This cookbook uses Test Kitchen to do cross-platform convergence and

--- a/definitions/splunk_installer.rb
+++ b/definitions/splunk_installer.rb
@@ -51,16 +51,14 @@ define :splunk_installer, :url => nil do
     end
   end
 
-  package params[:name] do
+  local_package_resource = case node['platform_family']
+                           when 'rhel'   then :rpm_package
+                           when 'debian' then :dpkg_package
+                           when 'omnios' then :solaris_package
+                           end
+
+  declare_resource local_package_resource, params[:name] do
     source cached_package.gsub(/\.Z/, '')
-    case node['platform_family']
-    when 'rhel'
-      provider Chef::Provider::Package::Rpm
-    when 'debian'
-      provider Chef::Provider::Package::Dpkg
-    when 'omnios'
-      provider Chef::Provider::Package::Solaris
-      options pkgopts.join(' ')
-    end
+    options pkgopts.join(' ') if platform?('omnios')
   end
 end

--- a/spec/recipes/install_forwarder_spec.rb
+++ b/spec/recipes/install_forwarder_spec.rb
@@ -17,7 +17,7 @@ describe 'chef-splunk::install_forwarder' do
     end
 
     it 'installs the package with the downloaded file' do
-      expect(chef_run).to install_package('splunkforwarder').with(
+      expect(chef_run).to install_dpkg_package('splunkforwarder').with(
         'source' => "#{Chef::Config[:file_cache_path]}/package.deb"
       )
     end
@@ -39,7 +39,7 @@ describe 'chef-splunk::install_forwarder' do
     end
 
     it 'installs the package with the downloaded file' do
-      expect(chef_run).to install_package('splunkforwarder').with(
+      expect(chef_run).to install_rpm_package('splunkforwarder').with(
         'source' => "#{Chef::Config[:file_cache_path]}/package.rpm"
       )
     end
@@ -79,7 +79,7 @@ describe 'chef-splunk::install_forwarder' do
     end
 
     it 'installs the package with the downloaded file' do
-      expect(chef_run).to install_package('splunkforwarder').with(
+      expect(chef_run).to install_solaris_package('splunkforwarder').with(
         'source' => "#{Chef::Config[:file_cache_path]}/package.pkg",
         'options' => "-a #{Chef::Config[:file_cache_path]}/splunkforwarder-nocheck -r #{Chef::Config[:file_cache_path]}/splunk-response"
       )

--- a/spec/recipes/install_server_spec.rb
+++ b/spec/recipes/install_server_spec.rb
@@ -17,7 +17,7 @@ describe 'chef-splunk::install_server' do
     end
 
     it 'installs the package with the downloaded file' do
-      expect(chef_run).to install_package('splunk').with(
+      expect(chef_run).to install_dpkg_package('splunk').with(
         'source' => "#{Chef::Config[:file_cache_path]}/package.deb"
       )
     end
@@ -39,7 +39,7 @@ describe 'chef-splunk::install_server' do
     end
 
     it 'installs the package with the downloaded file' do
-      expect(chef_run).to install_package('splunk').with(
+      expect(chef_run).to install_rpm_package('splunk').with(
         'source' => "#{Chef::Config[:file_cache_path]}/package.rpm"
       )
     end
@@ -79,7 +79,7 @@ describe 'chef-splunk::install_server' do
     end
 
     it 'installs the package with the downloaded file' do
-      expect(chef_run).to install_package('splunk').with(
+      expect(chef_run).to install_solaris_package('splunk').with(
         'source' => "#{Chef::Config[:file_cache_path]}/package.pkg",
         'options' => "-a #{Chef::Config[:file_cache_path]}/splunk-nocheck -r #{Chef::Config[:file_cache_path]}/splunk-response"
       )

--- a/spec/recipes/upgrade_spec.rb
+++ b/spec/recipes/upgrade_spec.rb
@@ -24,7 +24,7 @@ describe 'chef-splunk::upgrade' do
   end
 
   it 'installs the package with splunk_installer' do
-    expect(chef_run).to install_package('splunkforwarder')
+    expect(chef_run).to install_dpkg_package('splunkforwarder')
   end
 
   it 'runs an unattended upgrade (starts splunk)' do


### PR DESCRIPTION
Per this comment:

https://github.com/chef/chef/issues/3487#issuecomment-110446611

We should not use the `provider` property of resources. We should instead use the DSL method, #declare_resource. This commit converts the definition to use that method.