### PR TITLE
Adds the ability for users to configure the auth vault name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,9 @@ named `vault`, with an item `splunk_CHEF-ENVIRONMENT`, where
 Enterprise server will be assigned. If environments are not used, use
 `_default`. For example in a Chef Repository (not in a cookbook):
 
+Users may configure the auth vault and item name via the `auth_options` hash 
+in the default attributes. 
+
     % cat data_bags/vault/splunk__default.json
     {
       "id": "splunk__default",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,12 @@ default['splunk']['ssl_options'] = {
   'crtfile' => 'self-signed.example.com.crt'
 }
 
+# nil data_bag_item key uses default of splunk_'node.chef_environment'
+default['splunk']['auth_options'] = {
+  'data_bag' => 'vault',
+  'data_bag_item' => nil
+}
+
 # Add key value pairs to this to add configuration pairs to the output.conf file
 # 'sslCertPath' => '$SPLUNK_HOME/etc/certs/cert.pem'
 default['splunk']['outputs_conf'] = {

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -25,7 +25,11 @@ include_recipe 'chef-splunk::setup_auth'
 
 # We can rely on loading the chef_vault_item here, as `setup_auth`
 # above would have failed if there were another issue.
-splunk_auth_info = chef_vault_item(:vault, "splunk_#{node.chef_environment}")['auth']
+auth_options = node['splunk']['auth_options']
+
+splunk_auth_info = chef_vault_item(
+  auth_options['data_bag'],
+  auth_options['data_bag_item'] || "splunk_#{node.chef_environment}")['auth']
 
 execute 'enable-splunk-receiver-port' do
   command "#{splunk_cmd} enable listen #{node['splunk']['receiver_port']} -auth '#{splunk_auth_info}'"

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -17,9 +17,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe 'chef-vault'
 
-splunk_auth_info = chef_vault_item(:vault, "splunk_#{node.chef_environment}")['auth']
+chef_gem 'chef-vault'
+  compile_time true if respond_to?(:compile_time)
+  version '1.0.4'
+end
+require 'chef-vault'
+
+auth_options = node['splunk']['auth_options']
+ 
+splunk_auth_info = chef_vault_item(
+  auth_options['data_bag'],
+  auth_options['data_bag_item'] || "splunk_#{node.chef_environment}")['auth']
+
 user, pw = splunk_auth_info.split(':')
 
 execute 'change-admin-user-password-from-default' do


### PR DESCRIPTION
Users may now specify the vault name and item for the auth credentials
of the default user used in the setup_auth recipe. This enables users
who have custom chef_vault organization to easily use the setup_auth
recipe.

The defaults remain: 'vault' and 'splunk_<node.chef_environment>'.