### PR TITLE
Make splunk_app install/enable work as non-root user

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -105,3 +105,15 @@ suites:
         accept_license: true
         upgrade_enabled: true
         is_server: true
+
+  - name: server_lwrps
+    run_list:
+      - recipe[chef-splunk::default]
+      - recipe[test::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        server:
+          runasroot: false
+        accept_license: true
+        is_server: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -117,3 +117,15 @@ suites:
           runasroot: false
         accept_license: true
         is_server: true
+
+  - name: client_lwrps
+    run_list:
+      - recipe[chef-splunk::default]
+      - recipe[test::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        server:
+          runasroot: false
+        accept_license: true
+        is_server: false

--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -68,12 +68,13 @@ class Chef
           end
         end
 
-        if new_resource.templates
-          directory "#{app_dir}/local" do
-            recursive true
-            mode 00755
-          end
+        directory "#{app_dir}/local" do
+          recursive true
+          mode 00755
+          owner node['splunk']['user']['username'] unless node['splunk']['server']['runasroot']
+        end
 
+        if new_resource.templates
           new_resource.templates.each do |t|
             template "#{app_dir}/local/#{t}" do
               source "#{new_resource.app_name}/#{t}.erb"

--- a/test/integration/client_lwrps/serverspec/spec_helper.rb
+++ b/test/integration/client_lwrps/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/client_lwrps/serverspec/splunkapp_spec.rb
+++ b/test/integration/client_lwrps/serverspec/splunkapp_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'splunk apps should be installed and enabled' do
+  describe file('/opt/splunkforwarder/etc/apps/bistro-1.0.2') do
+    it { should exist }
+    it { should be_directory }
+    it { should be_owned_by 'splunk' }
+  end
+  describe command("/opt/splunkforwarder/bin/splunk btool --app=bistro-1.0.2 app list") do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should_not match /disabled\s*=\s*(0|false)/ }
+  end
+end

--- a/test/integration/server_lwrps/serverspec/spec_helper.rb
+++ b/test/integration/server_lwrps/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/server_lwrps/serverspec/splunkapp_spec.rb
+++ b/test/integration/server_lwrps/serverspec/splunkapp_spec.rb
@@ -6,9 +6,8 @@ describe 'splunk apps should be installed and enabled' do
     it { should be_directory }
     it { should be_owned_by 'splunk' }
   end
-  describe command("/opt/splunk/bin/splunk btool --debug --app=bistro-1.0.2 app list") do
-    it 'should enable the app' do
-      expect(:stdout).to match(/disabled\s*=\s*(0|false)/)
-    end
+  describe command("/opt/splunk/bin/splunk btool --app=bistro-1.0.2 app list") do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should_not match /disabled\s*=\s*(0|false)/ }
   end
 end

--- a/test/integration/server_lwrps/serverspec/splunkapp_spec.rb
+++ b/test/integration/server_lwrps/serverspec/splunkapp_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'splunk apps should be installed and enabled' do
+  describe file('/opt/splunk/etc/apps/bistro-1.0.2') do
+    it { should exist }
+    it { should be_directory }
+    it { should be_owned_by 'splunk' }
+  end
+  describe command("/opt/splunk/bin/splunk btool --debug --app=bistro-1.0.2 app list") do
+    it 'should enable the app' do
+      expect(:stdout).to match(/disabled\s*=\s*(0|false)/)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #48.
The fix is to ensure that there is a `local` folder with the correct owner after installing the app.