### PR TITLE
fix missing provides statement in splunk_app provider

### DIFF
--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -24,6 +24,9 @@ include Chef::Mixin::ShellOut
 class Chef
   class Provider
     class SplunkApp < Chef::Provider::LWRPBase
+
+      provides :splunk_app
+
       use_inline_resources if defined?(:use_inline_resources)
 
       def whyrun_supported?


### PR DESCRIPTION
This will remove warnings such as the following:

    Recipe: test::default
         * splunk_app[bistro-remote-file] action install[2015-08-17T00:35:34+00:00] WARN: Class Chef::Provider::SplunkApp does not declare 'resource_name :splunk_app'.
       [2015-08-17T00:35:34+00:00] WARN: This will no longer work in Chef 13: you must use 'resource_name' to provide DSL.