### PR TITLE
Make setup_auth optional on client install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ General attributes:
   listens to. This is set to the default for HTTPS, 443, as it is
   configured by the `setup_ssl` recipe.
 * `node['splunk']['ratelimit_kilobytessec']`: The default splunk rate limiting rate can now easily be changed with an attribute.  Default is 2048KBytes/sec.
+* `node['splunk']['setup_auth']`: Allow the client to optionaly not configure auth on a client install.
 
 The two URL attributes below are selected by platform and architecture
 by default.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -67,6 +67,8 @@ default['splunk']['user']['home'] = '/opt/splunk' if node['splunk']['is_server']
 
 default['splunk']['server']['runasroot'] = true
 
+default['splunk']['setup_auth'] = true
+
 case node['platform_family']
 when 'rhel'
   if node['kernel']['machine'] == 'x86_64'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -69,4 +69,4 @@ template "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/limits.conf" d
 end
 
 include_recipe 'chef-splunk::service'
-include_recipe 'chef-splunk::setup_auth'
+include_recipe 'chef-splunk::setup_auth' if node['splunk']['setup_auth']


### PR DESCRIPTION
This pull request cleans up this one: https://github.com/chef-cookbooks/chef-splunk/pull/38