### PR TITLE
Run kitchen tests in Travis-CI

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -1,0 +1,135 @@
+settings:
+  parallel: true
+
+driver:
+  name: docker
+  # privileged is required otherwise the container doesn't boot right
+  privileged: true
+
+provisioner:
+  data_bags_path: "test/fixtures/data_bags"
+
+platforms:
+- name: centos-6
+  driver:
+    image: centos:6
+    platform: rhel
+    run_command: /sbin/init
+    provision_command:
+      - /usr/bin/yum install -y initscripts net-tools wget
+- name: centos-7
+  driver:
+    image: centos:7
+    platform: rhel
+    run_command: /usr/lib/systemd/systemd
+    provision_command:
+      - /bin/yum install -y initscripts net-tools wget
+- name: ubuntu-12.04
+  driver:
+    image: ubuntu-upstart:12.04
+    platform: ubuntu
+    disable_upstart: false
+    run_command: /sbin/init
+    provision_command:
+      - /usr/bin/apt-get update
+      - /usr/bin/apt-get install apt-transport-https net-tools -y
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu-upstart:14.04
+    platform: ubuntu
+    disable_upstart: false
+    run_command: /sbin/init
+    provision_command:
+      - /usr/bin/apt-get update
+      - /usr/bin/apt-get install apt-transport-https net-tools -y
+
+suites:
+  - name: client
+    run_list:
+      - recipe[chef-splunk::default]
+      - recipe[test::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        accept_license: true
+
+  - name: client-inputs-outputs
+    run_list:
+      - recipe[chef-splunk::default]
+      - recipe[test::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        accept_license: true
+        outputs_conf:
+          sslCommonNameToCheck: sslCommonName
+          sslCertPath: $SPLUNK_HOME/etc/certs/cert.pem
+          sslPassword: password
+          sslRootCAPath: $SPLUNK_HOME/etc/certs/cacert.pem
+          sslVerifyServerCert: false
+        inputs_conf:
+          host: localhost
+          ports:
+            - port_num: 123123
+              config:
+                connection_host: dns
+                sourcetype: syslog
+                source: tcp:123123
+
+  - name: server-runas-root
+    run_list:
+      - recipe[chef-splunk::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        server:
+          runasroot: true
+        is_server: true
+        accept_license: true
+        ssl_options:
+          enable_ssl: true
+
+  - name: server-runas-splunk
+    run_list:
+      - recipe[chef-splunk::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        server:
+          runasroot: false
+        is_server: true
+        accept_license: true
+        ssl_options:
+          enable_ssl: true
+        web_port: 8443
+
+  - name: disabled
+    run_list:
+      - recipe[chef-splunk::default]
+    attributes:
+      splunk:
+        disabled: true
+
+  - name: server_lwrps
+    run_list:
+      - recipe[chef-splunk::default]
+      - recipe[test::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        server:
+          runasroot: false
+        accept_license: true
+        is_server: true
+
+  - name: client_lwrps
+    run_list:
+      - recipe[chef-splunk::default]
+      - recipe[test::default]
+    attributes:
+      dev_mode: true
+      splunk:
+        server:
+          runasroot: false
+        accept_license: true
+        is_server: false

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -6,6 +6,10 @@ driver:
   # privileged is required otherwise the container doesn't boot right
   privileged: true
 
+driver_config:
+  volume:
+    - /data/splunk-test:/opt/splunk/var/lib
+
 provisioner:
   data_bags_path: "test/fixtures/data_bags"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Use Travis's cointainer based infrastructure
+# Use Travis's legacy infrastructure
 sudo: required
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Use Travis's cointainer based infrastructure
-sudo: false
+sudo: required
+
 addons:
   apt:
     sources:
@@ -14,11 +15,25 @@ branches:
   only:
     - master
 
+services: docker
+
+env:
+  matrix:
+    - INSTANCE=server-runas-splunk-ubuntu-1404
+    - INSTANCE=client-runas-splunk-ubuntu-1404
+    - INSTANCE=server-runas-splunk-centos-7
+    - INSTANCE=client-runas-splunk-centos-7
+    - INSTANCE=fpm-test-ubuntu-1404
+    - INSTANCE=fpm-test-centos-7
+
 # Ensure we make ChefDK's Ruby the default
 before_script:
+  # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
   # We have to install chef-sugar for ChefSpec
   - /opt/chefdk/embedded/bin/chef gem install chef-sugar
+  - /opt/chefdk/embedded/bin/chef gem install kitchen-docker
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version
@@ -26,3 +41,4 @@ script:
   - /opt/chefdk/embedded/bin/foodcritic --version
   - /opt/chefdk/embedded/bin/foodcritic . --exclude spec
   - /opt/chefdk/embedded/bin/rspec spec
+  - KITCHEN_LOCAL_YAML=.kitchen.docker.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,7 @@ before_script:
   - /opt/chefdk/embedded/bin/chef gem install kitchen-docker
   # workaround for "unusable filesystem" error in splunk
   # https://answers.splunk.com/answers/9035/can-i-run-splunk-on-btrfs.html#answer-152672
-  - sudo dd if=/dev/zero of=/opt/splunk-var-blockfile bs=4096 count=10240
-  - sudo mkfs.ext4 -F /opt/splunk-var-blockfile
-  - sudo mkdir -p /opt/splunk/var
-  - sudo mount /opt/splunk-var-blockfile /opt/splunk/var
+  - sudo mkdir -p /data/splunk-test
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   # workaround for "unusable filesystem" error in splunk
   # https://answers.splunk.com/answers/9035/can-i-run-splunk-on-btrfs.html#answer-152672
   - sudo dd if=/dev/zero of=/opt/splunk-var-blockfile bs=4096 count=10240
-  - sudo mkfs.ext4 /opt/splunk-var-blockfile
+  - sudo mkfs.ext4 -F /opt/splunk-var-blockfile
   - sudo mount /opt/splunk-var-blockfile /opt/splunk/var
 script:
   - /opt/chefdk/embedded/bin/chef --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install: echo "skip bundle install"
 
 branches:
   only:
-    - kitchen-travis
+    - master
 
 services: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,9 @@ services: docker
 env:
   matrix:
     - INSTANCE=server-runas-splunk-ubuntu-1404
-    - INSTANCE=client-runas-splunk-ubuntu-1404
+    - INSTANCE=client-inputs-outputs-ubuntu-1404
     - INSTANCE=server-runas-splunk-centos-7
-    - INSTANCE=client-runas-splunk-centos-7
-    - INSTANCE=fpm-test-ubuntu-1404
-    - INSTANCE=fpm-test-centos-7
+    - INSTANCE=client-inputs-outputs-centos-7
 
 # Ensure we make ChefDK's Ruby the default
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install: echo "skip bundle install"
 
 branches:
   only:
-    - master
+    - kitchen-travis
 
 services: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ before_script:
   # We have to install chef-sugar for ChefSpec
   - /opt/chefdk/embedded/bin/chef gem install chef-sugar
   - /opt/chefdk/embedded/bin/chef gem install kitchen-docker
+  # workaround for "unusable filesystem" error in splunk
+  # https://answers.splunk.com/answers/9035/can-i-run-splunk-on-btrfs.html#answer-152672
+  - sudo dd if=/dev/zero of=/opt/splunk-var-blockfile bs=4096 count=10240
+  - sudo mkfs.ext4 /opt/splunk-var-blockfile
+  - sudo mount /opt/splunk-var-blockfile /opt/splunk/var
 script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/rubocop --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
   # https://answers.splunk.com/answers/9035/can-i-run-splunk-on-btrfs.html#answer-152672
   - sudo dd if=/dev/zero of=/opt/splunk-var-blockfile bs=4096 count=10240
   - sudo mkfs.ext4 -F /opt/splunk-var-blockfile
+  - sudo mkdir -p /opt/splunk/var
   - sudo mount /opt/splunk-var-blockfile /opt/splunk/var
 script:
   - /opt/chefdk/embedded/bin/chef --version


### PR DESCRIPTION
There have been quite a few updates to this repository which resulted in failed kitchen tests.

The complexity of the test combinations (currently 8 platforms by 9 test suites = 72 tests in all) makes it difficult to run the full test suite for every change. Last night, I ran `kitchen test --concurrency 4` and it took around 2.5 hours on my machine (2.6GHz Core i7, 16GB RAM, 1TB SSD), and a lot (if not all) of the packages were already cached from previous runs. It would be really great if we could get test kitchen running from in Travis, like the other tests.

Currently I've only implemented 2 platforms (one centos and one ubuntu) and 2 test suites (one server and one client), but they work, and we can add more as necessary.