### PR TITLE
Systemd patch

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -97,7 +97,6 @@ else
       splunkdir: splunk_dir,
       runasroot: node['splunk']['server']['runasroot']
     )
-    only_if { node['init_package'] == 'init' }
   end
 
   service 'splunk' do

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -74,24 +74,6 @@ ruby_block 'splunk_fix_file_ownership' do
   not_if { node['splunk']['server']['runasroot'] }
 end
 
-if node['init_package'] == 'init'
-  template '/etc/init.d/splunk' do
-    source 'splunk-init.erb'
-    mode 0700
-    variables(
-      splunkdir: splunk_dir,
-      runasroot: node['splunk']['server']['runasroot']
-    )
-    only_if { node['init_package'] == 'init' }
-  end
-
-  service 'splunk' do
-    supports status: true, restart: true
-    provider Chef::Provider::Service::Init
-    action :start
-  end
-end
-
 if node['init_package'] == 'systemd'
   template '/usr/lib/systemd/system/splunk.service' do
     source 'splunk-systemd.erb'
@@ -106,5 +88,21 @@ if node['init_package'] == 'systemd'
     supports status: true, restart: true
     provider Chef::Provider::Service::Systemd
     action [:enable, :start]
+  end
+else
+  template '/etc/init.d/splunk' do
+    source 'splunk-init.erb'
+    mode 0700
+    variables(
+      splunkdir: splunk_dir,
+      runasroot: node['splunk']['server']['runasroot']
+    )
+    only_if { node['init_package'] == 'init' }
+  end
+
+  service 'splunk' do
+    supports status: true, restart: true
+    provider Chef::Provider::Service::Init
+    action :start
   end
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -81,6 +81,17 @@ template '/etc/init.d/splunk' do
     splunkdir: splunk_dir,
     runasroot: node['splunk']['server']['runasroot']
   )
+  only_if node['init_package'] == 'init'
+end
+
+template '/usr/lib/systemd/system/splunk.service' do
+  source 'splunk-systemd.erb'
+  mode 0700
+  variables(
+    splunkdir: splunk_dir,
+    runasroot: node['splunk']['server']['runasroot']
+  )
+  only_if node['init_package'] == 'systemd'
 end
 
 service 'splunk' do

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -105,6 +105,6 @@ if node['init_package'] == 'systemd'
   service 'splunk' do
     supports status: true, restart: true
     provider Chef::Provider::Service::Systemd
-    action :start
+    action [ :enable, :start ]
   end
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -74,7 +74,7 @@ ruby_block 'splunk_fix_file_ownership' do
   not_if { node['splunk']['server']['runasroot'] }
 end
 
-if node['init_package'] == 'init' do
+if node['init_package'] == 'init'
   template '/etc/init.d/splunk' do
     source 'splunk-init.erb'
     mode 0700
@@ -92,7 +92,7 @@ if node['init_package'] == 'init' do
   end
 end
 
-if node['init_package'] == 'systemd' do
+if node['init_package'] == 'systemd'
   template '/usr/lib/systemd/system/splunk.service' do
     source 'splunk-systemd.erb'
     mode 0700

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -81,7 +81,7 @@ template '/etc/init.d/splunk' do
     splunkdir: splunk_dir,
     runasroot: node['splunk']['server']['runasroot']
   )
-  only_if node['init_package'] == 'init'
+  only_if { node['init_package'] == 'init' }
 end
 
 template '/usr/lib/systemd/system/splunk.service' do
@@ -91,7 +91,7 @@ template '/usr/lib/systemd/system/splunk.service' do
     splunkdir: splunk_dir,
     runasroot: node['splunk']['server']['runasroot']
   )
-  only_if node['init_package'] == 'systemd'
+  only_if { node['init_package'] == 'systemd' }
 end
 
 service 'splunk' do

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -105,6 +105,6 @@ if node['init_package'] == 'systemd'
   service 'splunk' do
     supports status: true, restart: true
     provider Chef::Provider::Service::Systemd
-    action [ :enable, :start ]
+    action [:enable, :start]
   end
 end

--- a/templates/default/splunk-systemd.erb
+++ b/templates/default/splunk-systemd.erb
@@ -11,7 +11,7 @@ User=splunk
 <% end %>
 ExecStart=<%= @splunkdir %>/bin/splunk start --no-prompt --answer-yes
 ExecStop=<%= @splunkdir %>/bin/splunk stop
-PIDFile=<%= @splunkdir %>/var/run/splunk/splunk.pid
+PIDFile=<%= @splunkdir %>/var/run/splunk/splunkd.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/default/splunk-systemd.erb
+++ b/templates/default/splunk-systemd.erb
@@ -2,15 +2,17 @@
 
 [Unit]
 Description=Splunk
-After=syslog.target
+After=network.target
 
 [Service]
-Type=simple
+Type=forking
+RemainAfterExit=yes
 <% if ! @runasroot %>
 User=splunk
 <% end %>
 ExecStart=<%= @splunkdir %>/bin/splunk start --no-prompt --answer-yes
 ExecStop=<%= @splunkdir %>/bin/splunk stop
+ExecReload=<%= @splunkdir %>/bin/splunk restart
 PIDFile=<%= @splunkdir %>/var/run/splunk/splunkd.pid
 
 [Install]

--- a/templates/default/splunk-systemd.erb
+++ b/templates/default/splunk-systemd.erb
@@ -1,0 +1,17 @@
+# systemd service file for splunk
+
+[Unit]
+Description=Splunk
+After=syslog.target
+
+[Service]
+Type=forking
+<% if ! @runasroot %>
+User=splunk
+<% end %>
+ExecStart=<%= @splunkdir %>/splunk start --no-prompt --answer-yes
+ExecStop=<%= @splunkdir %>/splunk stop
+PIDFile=<%= @splunkdir %>/var/run/splunk/splunk.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/splunk-systemd.erb
+++ b/templates/default/splunk-systemd.erb
@@ -5,7 +5,7 @@ Description=Splunk
 After=syslog.target
 
 [Service]
-Type=forking
+Type=simple
 <% if ! @runasroot %>
 User=splunk
 <% end %>

--- a/templates/default/splunk-systemd.erb
+++ b/templates/default/splunk-systemd.erb
@@ -9,8 +9,8 @@ Type=forking
 <% if ! @runasroot %>
 User=splunk
 <% end %>
-ExecStart=<%= @splunkdir %>/splunk start --no-prompt --answer-yes
-ExecStop=<%= @splunkdir %>/splunk stop
+ExecStart=<%= @splunkdir %>/bin/splunk start --no-prompt --answer-yes
+ExecStop=<%= @splunkdir %>/bin/splunk stop
 PIDFile=<%= @splunkdir %>/var/run/splunk/splunk.pid
 
 [Install]


### PR DESCRIPTION
This patch adds support for systemd. It will install a systemd configuration file on systems that support it instead of placing a file in /etc/init.d.

One caveat, there will still be a /etc/init.d/splunk file installed via. the "splunk enable boot-start" command. Since that command is what accepts the license agreement, I didn't see an easy way to remove/replace it.