### PR TITLE
Splunk password encryption helper

### DIFF
--- a/libraries/crypto.rb
+++ b/libraries/crypto.rb
@@ -72,10 +72,9 @@ module Splunk
 
   def splunk_encrypted_password(plaintext)
     pwd = plaintext.unpack('c*')
-    secret_file = ::File.join(node['splunk']['user']['home'],
-                              'etc/auth/splunk.secret')
+    secret_file = ::File.join(splunk_dir, 'etc', 'auth', 'splunk.secret')
 
-    rc4key = ::IO.read(secret_file).strip![0..15]
+    rc4key = ::IO.read(secret_file)[0..15].chomp
     xorkey = 'DEFAULTSA'.unpack('c*')
     xorkey += xorkey while xorkey.size < pwd.size
 

--- a/libraries/crypto.rb
+++ b/libraries/crypto.rb
@@ -44,13 +44,13 @@ module Splunk
       text
     end
 
-    alias :decrypt! :encrypt!
+    alias decrypt! encrypt!
 
     def encrypt(text)
       encrypt!(text.dup)
     end
 
-    alias :decrypt :encrypt
+    alias decrypt encrypt
 
     private
 

--- a/libraries/crypto.rb
+++ b/libraries/crypto.rb
@@ -1,3 +1,23 @@
+#
+# Cookbook Name:: splunk
+# Libraries:: crypto
+#
+# Author: Marat Vyshegorodtsev <marat.vyshegorodtsev@gmail.com>
+# Copyright (c) 2016, Bonakodo Limited <office@bonakodo.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require 'base64'
 
 # This file provides helpers for password encryption used by Splunk

--- a/libraries/crypto.rb
+++ b/libraries/crypto.rb
@@ -1,0 +1,66 @@
+require 'base64'
+
+# This file provides helpers for password encryption used by Splunk
+module Splunk
+  # RC4 implementation taken from https://github.com/caiges/Ruby-RC4
+  class RC4
+    def initialize(str)
+      fail SyntaxError, 'RC4: Key supplied is blank' if str.eql?('')
+      initialize_state(str)
+      @q1 = 0
+      @q2 = 0
+    end
+
+    def encrypt!(text)
+      index = 0
+      while index < text.length
+        @q1 = (@q1 + 1) % 256
+        @q2 = (@q2 + @state[@q1]) % 256
+        @state[@q1], @state[@q2] = @state[@q2], @state[@q1]
+        text.setbyte(index, text.getbyte(index) ^ @state[
+          (@state[@q1] + @state[@q2]) % 256])
+        index += 1
+      end
+      text
+    end
+
+    alias_method :decrypt!, :encrypt!
+
+    def encrypt(text)
+      encrypt!(text.dup)
+    end
+
+    alias_method :decrypt, :encrypt
+
+    private
+
+    # The initial state which is then modified by the key-scheduling algorithm
+    INITIAL_STATE = (0..255).to_a
+
+    # Performs the key-scheduling algorithm to initialize the state.
+    def initialize_state(key)
+      i = j = 0
+      @state = INITIAL_STATE.dup
+      key_length = key.length
+      while i < 256
+        j = (j + @state[i] + key.getbyte(i % key_length)) % 256
+        @state[i], @state[j] = @state[j], @state[i]
+        i += 1
+      end
+    end
+  end
+
+  def splunk_encrypted_password(plaintext)
+    pwd = plaintext.unpack('c*')
+    secret_file = ::File.join(node['splunk']['user']['home'],
+                              'etc/auth/splunk.secret')
+
+    rc4key = ::IO.read(secret_file).strip![0..15]
+    xorkey = 'DEFAULTSA'.unpack('c*')
+    xorkey += xorkey while xorkey.length < pwd.length
+
+    pwd = pwd.zip(xorkey).collect { |c1, c2| c1 ^ c2 }.pack('c*') + "\0"
+    pwd = Splunk::RC4.new(rc4key).encrypt(pwd)
+    '$1$' + Base64.encode64(pwd).strip!
+  end
+end

--- a/libraries/crypto.rb
+++ b/libraries/crypto.rb
@@ -57,9 +57,9 @@ module Splunk
 
     rc4key = ::IO.read(secret_file).strip![0..15]
     xorkey = 'DEFAULTSA'.unpack('c*')
-    xorkey += xorkey while xorkey.length < pwd.length
+    xorkey += xorkey while xorkey.size < pwd.size
 
-    pwd = pwd.zip(xorkey).collect { |c1, c2| c1 ^ c2 }.pack('c*') + "\0"
+    pwd = pwd.zip(xorkey).map { |c1, c2| c1 ^ c2 }.pack('c*') + "\0"
     pwd = Splunk::RC4.new(rc4key).encrypt(pwd)
     '$1$' + Base64.encode64(pwd).strip!
   end

--- a/libraries/crypto.rb
+++ b/libraries/crypto.rb
@@ -25,7 +25,7 @@ module Splunk
   # RC4 implementation taken from https://github.com/caiges/Ruby-RC4
   class RC4
     def initialize(str)
-      fail SyntaxError, 'RC4: Key supplied is blank' if str.eql?('')
+      raise SyntaxError, 'RC4: Key supplied is blank' if str.eql?('')
       initialize_state(str)
       @q1 = 0
       @q2 = 0
@@ -44,13 +44,13 @@ module Splunk
       text
     end
 
-    alias_method :decrypt!, :encrypt!
+    alias :decrypt! :encrypt!
 
     def encrypt(text)
       encrypt!(text.dup)
     end
 
-    alias_method :decrypt, :encrypt
+    alias :decrypt :encrypt
 
     private
 


### PR DESCRIPTION
As you might now, any config that contains passwords in splunk works really bad with chef.

Splunk doesn't disclose their encryption method, so it is very hard to do recipes with credentials. This helper fixes it.

For example, setting up LDAP in a recipe:

``` ruby
template '/opt/splunk/etc/system/local/authentication.conf' do
  source 'authentication.conf.erb'
  owner 'root'
  group 'root'
  mode 00600
  helpers(Splunk)
  variables(pwd: 'MyVerySecureLDAPPassword123')
  notifies :restart, 'service[splunk]', :delayed
end
```

Where `authentication.conf.erb` may look like this:

```
[MyLDAP]
...
bindDN = <%= node['splunk']['ldap']['bindDN'] %>
bindDNpassword = <%= splunk_encrypted_password(@pwd) %>
...
```

Cool stuff, huh? :smirk:

Disclaimer: I'm a security engineer and not a ruby developer (I code in Perl), sorry for code quality
