### PR TITLE
Update Splunk version to 6.4.0 for all non-removed platforms

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,21 +71,21 @@ default['splunk']['server']['runasroot'] = true
 case node['platform_family']
 when 'rhel', 'fedora'
   if node['kernel']['machine'] == 'x86_64'
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.3.3/linux/splunkforwarder-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm'
-    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-x86_64.rpm'
+    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108-linux-2.6-x86_64.rpm'
+    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.4.0/linux/splunk-6.4.0-f2c836328108-linux-2.6-x86_64.rpm'
   else
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.3.3/linux/splunkforwarder-6.3.3-f44afce176d0.i386.rpm'
+    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108.i386.rpm'
     default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0.i386.rpm'
   end
 when 'debian'
   if node['kernel']['machine'] == 'x86_64'
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.3.3/linux/splunkforwarder-6.3.3-f44afce176d0-linux-2.6-amd64.deb'
-    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-amd64.deb'
+    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108-linux-2.6-amd64.deb'
+    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.4.0/linux/splunk-6.4.0-f2c836328108-linux-2.6-amd64.deb'
   else
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.3.3/linux/splunkforwarder-6.3.3-f44afce176d0-linux-2.6-intel.deb'
+    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108-linux-2.6-intel.deb'
     default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-intel.deb'
   end
 when 'omnios'
-  default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.3.3/solaris/splunkforwarder-6.3.3-f44afce176d0-solaris-10-intel.pkg.Z'
-  default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/solaris/splunk-6.3.3-f44afce176d0-solaris-10-intel.pkg.Z'
+  default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/solaris/splunkforwarder-6.4.0-f2c836328108-solaris-10-intel.pkg.Z'
+  default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.4.0/solaris/splunk-6.4.0-f2c836328108-solaris-10-intel.pkg.Z'
 end


### PR DESCRIPTION
URLs updated to 6.4 for appropriate platforms. Splunk Enterprise support for 32-bit Linux has been removed. See [release notes](http://docs.splunk.com/Documentation/Splunk/6.4.0/ReleaseNotes/Deprecatedfeatures) for more details.