### PR TITLE
GH-77: update download urls to 6.4.2 where possible

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,21 +71,21 @@ default['splunk']['server']['runasroot'] = true
 case node['platform_family']
 when 'rhel', 'fedora'
   if node['kernel']['machine'] == 'x86_64'
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108-linux-2.6-x86_64.rpm'
-    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.4.0/linux/splunk-6.4.0-f2c836328108-linux-2.6-x86_64.rpm'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822-linux-2.6-x86_64.rpm'
+    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.4.2/linux/splunk-6.4.2-00f5bb3fa822-linux-2.6-x86_64.rpm'
   else
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108.i386.rpm'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822.i386.rpm'
     default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0.i386.rpm'
   end
 when 'debian'
   if node['kernel']['machine'] == 'x86_64'
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108-linux-2.6-amd64.deb'
-    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.4.0/linux/splunk-6.4.0-f2c836328108-linux-2.6-amd64.deb'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822-linux-2.6-amd64.deb'
+    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.4.2/linux/splunk-6.4.2-00f5bb3fa822-linux-2.6-amd64.deb'
   else
-    default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/linux/splunkforwarder-6.4.0-f2c836328108-linux-2.6-intel.deb'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822-linux-2.6-intel.deb'
     default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-intel.deb'
   end
 when 'omnios'
-  default['splunk']['forwarder']['url'] = 'http://download.splunk.com/products/universalforwarder/releases/6.4.0/solaris/splunkforwarder-6.4.0-f2c836328108-solaris-10-intel.pkg.Z'
-  default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.4.0/solaris/splunk-6.4.0-f2c836328108-solaris-10-intel.pkg.Z'
+  default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/solaris/splunkforwarder-6.4.2-00f5bb3fa822-solaris-10-intel.pkg.Z'
+  default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.4.2/solaris/splunk-6.4.2-00f5bb3fa822-solaris-10-intel.pkg.Z'
 end


### PR DESCRIPTION
### Description

Updates download urls to 6.4.2 where possible. (Obvious fix.)

### Issues Resolved

GH-77

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] ~~New functionality includes testing.~~
- [x] ~~New functionality has been documented in the README if applicable~~
- [x] ~~The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD~~


