### PR TITLE
update README.md to fix typo in clustering enabled attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ clustering in the `setup_clustering` recipe:
 
 * `node['splunk']['clustering']`: A hash of indexer clustering configurations
   used in the `setup_clustering` recipe
-* `node['splunk']['clustering']['enable']`: Whether to enable indexer clustering,
+* `node['splunk']['clustering']['enabled']`: Whether to enable indexer clustering,
   must be set to `true` to use the `setup_clustering` recipe. Defaults to `false`,
   must be a boolean literal `true` or `false`.
 * `node['splunk']['clustering']['mode']`: The clustering mode of the node within

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ then that file should be removed.
 
 This recipe sets up Splunk indexer clustering based on the node's
 clustering mode or `node['splunk']['clustering']['mode']`. The attribute
-`node['splunk']['clustering']['enable']` must be set to true in order to
+`node['splunk']['clustering']['enabled']` must be set to true in order to
 run this recipe. Similar to `setup_auth`, this recipes loads
 the same encrypted data bag with the Splunk `secret` key (to be shared among
 cluster members), using the [chef-vault cookbook](http://ckbk.it/chef-vault)


### PR DESCRIPTION
### Description

This updates the README to fix a typo in the clustering attributes for enabling indexer clusters.
