### PR TITLE
Correcting clustering flag attribute documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ clustering in the `setup_clustering` recipe:
 
 * `node['splunk']['clustering']`: A hash of indexer clustering configurations
   used in the `setup_clustering` recipe
-* `node['splunk']['clustering']['enable']`: Whether to enable indexer clustering,
+* `node['splunk']['clustering']['enabled']`: Whether to enable indexer clustering,
   must be set to `true` to use the `setup_clustering` recipe. Defaults to `false`,
   must be a boolean literal `true` or `false`.
 * `node['splunk']['clustering']['mode']`: The clustering mode of the node within


### PR DESCRIPTION
### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


The documentation calls this flag 'node['splunk']['clustering']['enable']' when the chef-splunk/attributes/default.rb file declares this as 'enabled'.

Snippet of attributes/default.rb:

```
default['splunk']['clustering'] = {
  'enabled' => false,
  'mode' => 'master', # master|slave|searchhead
  'replication_factor' => 3,
  'search_factor' => 2,
  'replication_port' => 9887
}
```