### PR TITLE
Correction to typo of certificates in SSL options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ SSL in the `setup_ssl` recipe.
   load, defaults to `vault` (as chef-vault is used).
 * `node['splunk']['ssl_options']['data_bag_item']`: The data bag item
   name that contains the keyfile and crtfile, defaults to
-  `splunk_ceritficates`.
+  `splunk_certificates`.
 * `node['splunk']['ssl_options']['keyfile']`: The name of the SSL key
   file, and the content will be written to
   `etc/auth/splunkweb/KEYFILE`. Must be an element under `data` in the


### PR DESCRIPTION
### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Correction to typo of 'certificates' in SSL options attributes sections