### PR TITLE
GH-83: updated download urls to 6.5.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -73,21 +73,21 @@ default['splunk']['server']['runasroot'] = true
 case node['platform_family']
 when 'rhel', 'fedora'
   if node['kernel']['machine'] == 'x86_64'
-    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822-linux-2.6-x86_64.rpm'
-    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.4.2/linux/splunk-6.4.2-00f5bb3fa822-linux-2.6-x86_64.rpm'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c-linux-2.6-x86_64.rpm'
+    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.5.1/linux/splunk-6.5.1-f74036626f0c-linux-2.6-x86_64.rpm'
   else
-    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822.i386.rpm'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c.i386.rpm'
     default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0.i386.rpm'
   end
 when 'debian'
   if node['kernel']['machine'] == 'x86_64'
-    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822-linux-2.6-amd64.deb'
-    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.4.2/linux/splunk-6.4.2-00f5bb3fa822-linux-2.6-amd64.deb'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c-linux-2.6-amd64.deb'
+    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.5.1/linux/splunk-6.5.1-f74036626f0c-linux-2.6-amd64.deb'
   else
-    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/linux/splunkforwarder-6.4.2-00f5bb3fa822-linux-2.6-intel.deb'
+    default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c-linux-2.6-intel.deb'
     default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-intel.deb'
   end
 when 'omnios'
-  default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.4.2/solaris/splunkforwarder-6.4.2-00f5bb3fa822-solaris-10-intel.pkg.Z'
-  default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.4.2/solaris/splunk-6.4.2-00f5bb3fa822-solaris-10-intel.pkg.Z'
+  default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/solaris/splunkforwarder-6.5.1-f74036626f0c-solaris-10-intel.pkg.Z'
+  default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.5.1/solaris/splunk-6.5.1-f74036626f0c-solaris-10-intel.pkg.Z'
 end


### PR DESCRIPTION
### Description

Updates download urls to 6.5.1. (Obvious fix.)

[List any existing issues this PR resolves]

GH-83

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] ~~New functionality includes testing.~~
- [x] ~~New functionality has been documented in the README if applicable~~
- [x] ~~All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>~~

