### PR TITLE
Configure vault data bag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,9 @@ default['splunk']['receiver_port']  = '9997'
 default['splunk']['web_port']       = '443'
 default['splunk']['ratelimit_kilobytessec'] = '2048'
 
+default['splunk']['vault']['data_bag'] = 'vault'
+default['splunk']['vault']['data_bag_item'] = "splunk_#{node.chef_environment}"
+
 default['splunk']['setup_auth'] = true
 default['splunk']['user'] = {
   'username' => 'splunk',

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -24,7 +24,7 @@ include_recipe 'chef-splunk::setup_auth'
 
 # We can rely on loading the chef_vault_item here, as `setup_auth`
 # above would have failed if there were another issue.
-splunk_auth_info = chef_vault_item(:vault, "splunk_#{node.chef_environment}")['auth']
+splunk_auth_info = chef_vault_item(node['splunk']['vault']['data_bag'], node['splunk']['vault']['data_bag_item'])['auth']
 
 execute 'enable-splunk-receiver-port' do
   command "#{splunk_cmd} enable listen #{node['splunk']['receiver_port']} -auth '#{splunk_auth_info}'"

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -18,7 +18,7 @@
 #
 include_recipe 'chef-vault'
 
-splunk_auth_info = chef_vault_item(:vault, "splunk_#{node.chef_environment}")['auth']
+splunk_auth_info = chef_vault_item(node['splunk']['vault']['data_bag'], node['splunk']['vault']['data_bag_item'])['auth']
 user, pw = splunk_auth_info.split(':')
 
 execute 'change-admin-user-password-from-default' do

--- a/recipes/setup_clustering.rb
+++ b/recipes/setup_clustering.rb
@@ -33,7 +33,7 @@ end
 
 include_recipe 'chef-vault'
 
-passwords = chef_vault_item('vault', "splunk_#{node.chef_environment}")
+passwords = chef_vault_item(node['splunk']['vault']['data_bag'], node['splunk']['vault']['data_bag_item'])
 splunk_auth_info = passwords['auth']
 
 cluster_secret = passwords['secret']


### PR DESCRIPTION
Expose configuration for the name of the vault data bag and item.

Having multiple Splunk installations in the same Chef environment it is currently not possible to use a different password, because both will use the same vault data bag. With exposing these settings it will be possible to use a different data bag per installation while using the same environment.

Default are the same as the hardcoded values so backwards compatible.