### PR TITLE
Fix integration tests

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -11,7 +11,8 @@ provisioner:
   deprecations_as_errors: true
 
 verifier:
-  name: inspec
+  root_path: '/opt/verifier'
+  sudo: false
 
 platforms:
 - name: debian-7
@@ -21,7 +22,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: debian-8
   driver:
@@ -30,7 +37,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: centos-6
   driver:
@@ -39,7 +52,13 @@ platforms:
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN yum -y install lsof which initscripts net-tools wget net-tools
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: centos-7
   driver:
@@ -48,7 +67,13 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: fedora-latest
   driver:
@@ -56,7 +81,13 @@ platforms:
     pid_one_command: /usr/lib/systemd/systemd
     intermediate_instructions:
       - RUN dnf -y install which systemd-sysv initscripts wget net-tools
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: ubuntu-14.04
   driver:
@@ -65,7 +96,13 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: ubuntu-16.04
   driver:
@@ -74,14 +111,26 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-      - RUN sudo mkdir -p /data/splunk-test
+      - RUN mkdir -p /data/splunk-test
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 - name: opensuse-leap
   driver:
     image: opensuse:leap
     pid_one_command: /bin/systemd
     intermediate_instructions:
-      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
+      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools systemd-sysvinit 
+      # Disable file locking check by Splunk as it fails on unsupported file systems used in some Docker hosts (e.g. on Mac)
+      - RUN mkdir -p /opt/splunk/etc
+      - RUN printf '
+        SPLUNK_SERVER_NAME=Splunkd\n
+        SLPUNK_WEB_NAME=splunkweb\n
+        OPTIMISTIC_ABOUT_FILE_LOCKING=1\n' > /opt/splunk/etc/splunk-launch.conf
 
 suites:
   - name: client

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,13 +71,13 @@ default['splunk']['user']['home'] = '/opt/splunk' if node['splunk']['is_server']
 default['splunk']['server']['runasroot'] = true
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'suse'
   if node['kernel']['machine'] == 'x86_64'
     default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c-linux-2.6-x86_64.rpm'
     default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.5.1/linux/splunk-6.5.1-f74036626f0c-linux-2.6-x86_64.rpm'
   else
     default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c.i386.rpm'
-    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0.i386.rpm'
+    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0.i386.rpm'
   end
 when 'debian'
   if node['kernel']['machine'] == 'x86_64'
@@ -85,7 +85,7 @@ when 'debian'
     default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.5.1/linux/splunk-6.5.1-f74036626f0c-linux-2.6-amd64.deb'
   else
     default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/linux/splunkforwarder-6.5.1-f74036626f0c-linux-2.6-intel.deb'
-    default['splunk']['server']['url'] = 'http://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-intel.deb'
+    default['splunk']['server']['url'] = 'https://download.splunk.com/products/splunk/releases/6.3.3/linux/splunk-6.3.3-f44afce176d0-linux-2.6-intel.deb'
   end
 when 'omnios'
   default['splunk']['forwarder']['url'] = 'https://download.splunk.com/products/universalforwarder/releases/6.5.1/solaris/splunkforwarder-6.5.1-f74036626f0c-solaris-10-intel.pkg.Z'

--- a/definitions/splunk_installer.rb
+++ b/definitions/splunk_installer.rb
@@ -51,10 +51,10 @@ define :splunk_installer, url: nil do
   end
 
   local_package_resource = case node['platform_family']
-                           when 'rhel', 'fedora'  then :rpm_package
-                           when 'debian'          then :dpkg_package
-                           when 'omnios'          then :solaris_package
-                           end
+                  when 'rhel', 'fedora', 'suse'  then :rpm_package
+                  when 'debian'                  then :dpkg_package
+                  when 'omnios'                  then :solaris_package
+                  end
 
   declare_resource local_package_resource, params[:name] do
     source cached_package.gsub(/\.Z/, '')

--- a/definitions/splunk_installer.rb
+++ b/definitions/splunk_installer.rb
@@ -51,10 +51,10 @@ define :splunk_installer, url: nil do
   end
 
   local_package_resource = case node['platform_family']
-                  when 'rhel', 'fedora', 'suse'  then :rpm_package
-                  when 'debian'                  then :dpkg_package
-                  when 'omnios'                  then :solaris_package
-                  end
+                           when 'rhel', 'fedora', 'suse'  then :rpm_package
+                           when 'debian'                  then :dpkg_package
+                           when 'omnios'                  then :solaris_package
+                           end
 
   declare_resource local_package_resource, params[:name] do
     source cached_package.gsub(/\.Z/, '')

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -73,8 +73,10 @@ ruby_block 'splunk_fix_file_ownership' do
   not_if { node['splunk']['server']['runasroot'] }
 end
 
+Chef::Log.info("Node init package: #{node['init_package']}")
+
 if node['init_package'] == 'systemd'
-  template '/usr/lib/systemd/system/splunk.service' do
+  template '/etc/systemd/system/splunk.service' do
     source 'splunk-systemd.erb'
     mode '700'
     variables(


### PR DESCRIPTION
Enable Splunk to run with kitchen-dokken test on Travis CI.
Integration test server-runas-splunk passes on all included platforms.
