### PR TITLE
Support user-provided list of indexers for Splunk Forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ General attributes:
   listens to. This is set to the default for HTTPS, 443, as it is
   configured by the `setup_ssl` recipe.
 * `node['splunk']['ratelimit_kilobytessec']`: The default splunk rate limiting rate can now easily be changed with an attribute.  Default is 2048KBytes/sec.
+* `node['splunk']['splunk_servers']`: An alternative to using the Chef server search functionality to discover splunk
+  servers.
 
 The two URL attributes below are selected by platform and architecture
 by default.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ General attributes:
   listens to. This is set to the default for HTTPS, 443, as it is
   configured by the `setup_ssl` recipe.
 * `node['splunk']['ratelimit_kilobytessec']`: The default splunk rate limiting rate can now easily be changed with an attribute.  Default is 2048KBytes/sec.
-* `node['splunk']['splunk_servers']`: An alternative to using the Chef server search functionality to discover splunk
-  servers.
 
 The two URL attributes below are selected by platform and architecture
 by default.
@@ -165,11 +163,20 @@ forwardedindex.2.whitelist = _audit
 forwardedindex.filter.disable = false
 ```
 
-The `tcpout:splunk_indexers_9997` section is defined by the search results for Splunk Servers, and the `server` directive is a comma-separated listed of server IPs and the ports. For example, to add an `sslCertPath` directive, define the attribute in your role, wrapper cookbook, etc:
+As an example of `outputs_conf` attribute usage, to add an `sslCertPath` directive, define the attribute in your role or wrapper cookbook as such:
 
 ```
 node.default['splunk']['outputs_conf']['sslCertPath'] = '$SPLUNK_HOME/etc/certs/cert.pem'
 ```
+The `server` attribute in `tcpout:splunk_indexers_9997` stanza above is populated by default from Chef search results for Splunk servers, or, alternatively, is statically defined in node attribute `node['splunk']['server_list']`.
+
+`node['splunk']['server_list']` is an optional comma-separated listed of server IPs and the ports. It's only applicable when there are no Splunk servers managed by Chef, e.g. sending data to Splunk Cloud which has managed indexers.
+
+For example:
+```
+node.default['splunk']['server_list'] = '10.0.2.47:9997, 10.0.2.49:9997'
+```
+
 
 `node['splunk']['inputs_conf']` is a hash of configuration values that are used to populate the `inputs.conf` file.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,6 +70,8 @@ default['splunk']['user']['home'] = '/opt/splunk' if node['splunk']['is_server']
 
 default['splunk']['server']['runasroot'] = true
 
+default['splunk']['splunk_servers'] = []
+
 case node['platform_family']
 when 'rhel', 'fedora', 'suse'
   if node['kernel']['machine'] == 'x86_64'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -30,6 +30,14 @@ splunk_servers = search(
   a.name <=> b.name
 end
 
+if splunk_servers.empty?
+  splunk_servers = node['splunk']['splunk_servers']
+end
+
+if splunk_servers.empty?
+  splunk_servers = node['splunk']['splunk_servers']
+end
+
 # ensure that the splunk service resource is available without cloning
 # the resource (CHEF-3694). this is so the later notification works,
 # especially when using chefspec to run this cookbook's specs.

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -30,13 +30,12 @@ splunk_servers = search(
   a.name <=> b.name
 end
 
-if splunk_servers.empty?
-  splunk_servers = node['splunk']['splunk_servers']
-end
+server_list = splunk_servers.map do |s|
+  "#{s['fqdn'] || s['ipaddress']}:#{s['splunk']['receiver_port']}"
+end.join(', ')
 
-if splunk_servers.empty?
-  splunk_servers = node['splunk']['splunk_servers']
-end
+# fallback to statically defined server list as alternative to search
+server_list = node['splunk']['server_list'] if server_list.empty?
 
 # ensure that the splunk service resource is available without cloning
 # the resource (CHEF-3694). this is so the later notification works,
@@ -56,7 +55,10 @@ end
 template "#{splunk_dir}/etc/system/local/outputs.conf" do
   source 'outputs.conf.erb'
   mode '644'
-  variables splunk_servers: splunk_servers, outputs_conf: node['splunk']['outputs_conf']
+  variables(
+    server_list: server_list,
+    outputs_conf: node['splunk']['outputs_conf']
+  )
   notifies :restart, 'service[splunk]'
 end
 

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -53,7 +53,7 @@ describe 'chef-splunk::client' do
         s['fqdn'] + ':' + s['splunk']['receiver_port']
       end.join(', ')
       expect(chef_run).to render_file('/opt/splunkforwarder/etc/system/local/outputs.conf')
-        .with_content("server=#{server_list}")
+        .with_content("server = #{server_list}")
     end
 
     it 'notifies the splunk service to restart when rendering the outputs template' do
@@ -84,7 +84,7 @@ describe 'chef-splunk::client' do
 
     it 'writes outputs.conf with tcpout server list from node attribute' do
       expect(chef_run).to render_file('/opt/splunkforwarder/etc/system/local/outputs.conf')
-        .with_content('server=indexers.splunkcloud.com:9997')
+        .with_content('server = indexers.splunkcloud.com:9997')
     end
 
     it 'notifies the splunk service to restart when rendering the outputs template' do

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -1,41 +1,104 @@
 require_relative '../spec_helper'
 
 describe 'chef-splunk::client' do
-  let(:chef_run) do
-    ChefSpec::ServerRunner.new.converge(described_recipe)
-  end
-
   before(:each) do
     allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_return(true)
-    splunk_server = {}
-    splunk_server['hostname'] = 'spelunker'
-    splunk_server['ipaddress'] = '10.10.15.43'
-    splunk_server['splunk'] = {}
-    splunk_server['splunk']['receiver_port'] = '1648'
-    stub_search(:node, 'splunk_is_server:true AND chef_environment:_default').and_return([splunk_server])
   end
 
-  it 'creates the local system directory' do # ~FC005
-    expect(chef_run).to create_directory('/opt/splunkforwarder/etc/system/local').with(
-      'recursive' => true,
-      'owner' => 'splunk',
-      'group' => 'splunk'
-    )
+  context 'client config with remote indexers managed by Chef server' do
+    let(:splunk_indexer1) do
+      stub_node('idx1', platform: 'ubuntu', version: '12.04') do |node|
+        node.automatic['fqdn'] = 'idx1.example.com'
+        node.automatic['ipaddress'] = '10.10.15.43'
+        node.set['dev_mode'] = true
+        node.set['splunk']['is_server'] = true
+        node.set['splunk']['receiver_port'] = '1648'
+      end
+    end
+
+    let(:splunk_indexer2) do
+      stub_node('idx2', platform: 'ubuntu', version: '12.04') do |node|
+        node.automatic['hostname'] = 'spelunker'
+        node.automatic['fqdn'] = 'idx2.example.com'
+        node.automatic['ipaddress'] = '10.10.15.45'
+        node.set['dev_mode'] = true
+        node.set['splunk']['is_server'] = true
+        node.set['splunk']['receiver_port'] = '1648'
+      end
+    end
+
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node, server|
+        node.normal['dev_mode'] = true
+        # Publish mock indexer nodes to the server
+        server.create_node(splunk_indexer1)
+        server.create_node(splunk_indexer2)
+      end.converge(described_recipe)
+    end
+
+    it 'creates the local system directory' do # ~FC005
+      expect(chef_run).to create_directory('/opt/splunkforwarder/etc/system/local').with(
+        'recursive' => true,
+        'owner' => 'splunk',
+        'group' => 'splunk'
+      )
+    end
+
+    it 'creates an outputs template in the local system directory' do
+      expect(chef_run).to create_template('/opt/splunkforwarder/etc/system/local/outputs.conf')
+    end
+
+    it 'writes outputs.conf with tcpout server list from Chef search' do
+      server_list = [splunk_indexer1, splunk_indexer2].map do |s|
+        s['fqdn'] + ':' + s['splunk']['receiver_port']
+      end.join(', ')
+      expect(chef_run).to render_file('/opt/splunkforwarder/etc/system/local/outputs.conf')
+        .with_content("server=#{server_list}")
+    end
+
+    it 'notifies the splunk service to restart when rendering the outputs template' do
+      resource = chef_run.template('/opt/splunkforwarder/etc/system/local/outputs.conf')
+      expect(resource).to notify('service[splunk]').to(:restart)
+    end
   end
 
-  it 'creates an outputs template in the local system directory' do
-    expect(chef_run).to create_template('/opt/splunkforwarder/etc/system/local/outputs.conf')
+  context 'client config with remote indexers statically defined' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.normal['dev_mode'] = true
+        node.normal['splunk']['server_list'] = 'indexers.splunkcloud.com:9997'
+      end.converge(described_recipe)
+    end
+
+    it 'creates the local system directory' do # ~FC005
+      expect(chef_run).to create_directory('/opt/splunkforwarder/etc/system/local').with(
+        'recursive' => true,
+        'owner' => 'splunk',
+        'group' => 'splunk'
+      )
+    end
+
+    it 'creates an outputs template in the local system directory' do
+      expect(chef_run).to create_template('/opt/splunkforwarder/etc/system/local/outputs.conf')
+    end
+
+    it 'writes outputs.conf with tcpout server list from node attribute' do
+      expect(chef_run).to render_file('/opt/splunkforwarder/etc/system/local/outputs.conf')
+        .with_content('server=indexers.splunkcloud.com:9997')
+    end
+
+    it 'notifies the splunk service to restart when rendering the outputs template' do
+      resource = chef_run.template('/opt/splunkforwarder/etc/system/local/outputs.conf')
+      expect(resource).to notify('service[splunk]').to(:restart)
+    end
   end
 
-  it 'notifies the splunk service to restart when rendering the outputs template' do
-    resource = chef_run.template('/opt/splunkforwarder/etc/system/local/outputs.conf')
-    expect(resource).to notify('service[splunk]').to(:restart)
-  end
-
-  context 'inputs config has hosts' do
-    before(:each) do
-      chef_run.node.normal['splunk']['inputs_conf']['host'] = 'localhost'
-      chef_run.converge(described_recipe)
+  context 'client inputs config has hosts' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.normal['dev_mode'] = true
+        node.normal['splunk']['inputs_conf']['host'] = 'localhost'
+      end.converge(described_recipe)
     end
 
     it 'creates an inputs template in the local system directory if it has hosts' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,7 @@ RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
+
+  config.platform = 'ubuntu'
+  config.version = '16.04'
 end

--- a/templates/default/outputs.conf.erb
+++ b/templates/default/outputs.conf.erb
@@ -3,7 +3,7 @@ defaultGroup = splunk_indexers_<%= node['splunk']['receiver_port'] %>
 disabled=false
 
 [tcpout:splunk_indexers_<%= node['splunk']['receiver_port'] %>]
-server=<%= @server_list %>
+server = <%= @server_list %>
 <% @outputs_conf.each_pair do |name, value| -%>
 <%= name %> = <%= value %>
 <% end -%>

--- a/templates/default/outputs.conf.erb
+++ b/templates/default/outputs.conf.erb
@@ -3,7 +3,7 @@ defaultGroup = splunk_indexers_<%= node['splunk']['receiver_port'] %>
 disabled=false
 
 [tcpout:splunk_indexers_<%= node['splunk']['receiver_port'] %>]
-server=<% @splunk_servers.map do |s| -%><%= s['ipaddress'] %>:<%= s['splunk']['receiver_port'] %> <% end.join(', ') -%>
+server=<%= @server_list %>
 <% @outputs_conf.each_pair do |name, value| -%>
 <%= name %> = <%= value %>
 <% end -%>

--- a/test/integration/client-inputs-outputs/serverspec/client_spec.rb
+++ b/test/integration/client-inputs-outputs/serverspec/client_spec.rb
@@ -20,7 +20,7 @@ describe 'outputs config should be configured per node attributes' do
     its(:content) { should match(/forwardedindex.2.whitelist = _audit/) }
     its(:content) { should match(/forwardedindex.filter.disable = false/) }
     # servers
-    its(:content) { should match(/server = 10.0.2.47:9997/) }
+    its(:content) { should match(/server = server-ubuntu-1204.vagrantup.com:9997/) }
     # attributes for dynamic definition
     its(:content) { should match(/sslCertPath = \$SPLUNK_HOME\/etc\/certs\/cert.pem/) }
     its(:content) { should match(/sslCommonNameToCheck = sslCommonName/) }


### PR DESCRIPTION
### Description

Provides an alternative way to configure receiving indexers for Splunk Forwarder, without relying on Chef search for servers. This is required in cases of non-Chef managed Splunk servers e.g. Splunk Cloud.

### Issues Resolved

#15 #47 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
