### PR TITLE
set unit file to 644

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -78,7 +78,7 @@ Chef::Log.info("Node init package: #{node['init_package']}")
 if node['init_package'] == 'systemd'
   template '/etc/systemd/system/splunk.service' do
     source 'splunk-systemd.erb'
-    mode '700'
+    mode '644'
     variables(
       splunkdir: splunk_dir,
       runasroot: node['splunk']['server']['runasroot']


### PR DESCRIPTION
### Description

Changes the unit file created to 644. This eliminates warnings that are found in the systemd journal during startup. 

### Issues

Solves: https://github.com/chef-cookbooks/chef-splunk/issues/98

### Check List

- [X] All tests pass. 
--- The tests that are failing are the ones that have been failing previously.
- [X] New functionality includes testing.
--- Wasn't sure there was a need for testing on this
- [X] New functionality has been documented in the README if applicable
--- no new functionality
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
--- Falls under obvious fix policy
