### PR TITLE
Added more inputs.conf flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ is not overwritten if this is not set or is an empty string.
 * `node['splunk']['inputs_conf']['ports']`: An array of hashes that contain
 the input port configuration necessary to generate the inputs.conf
 file.
+* `node['splunk']['inputs_conf']['inputs']`: An array of hashes that contain
+the input configuration necessary to generate the inputs.conf
+file. This attribute supports all input types.
 
 For example:
 ```
@@ -246,6 +249,16 @@ node.default['splunk']['inputs_conf']['ports'] = [
     }
   }
 ]
+
+node.default['splunk']['inputs_conf']['inputs'] = [
+  {
+    input_path => 'monitor:///var/log/syslog',
+    config => {
+      'sourcetype' => 'syslog'
+    }
+  }
+]
+
 ```
 
 The following attributes are related to upgrades in the `upgrade`

--- a/templates/default/inputs.conf.erb
+++ b/templates/default/inputs.conf.erb
@@ -1,9 +1,20 @@
 [default]
 host = <%= @inputs_conf['host'] %>
 
+<% unless @inputs_conf['ports'].nil? %>
 <% @inputs_conf['ports'].each do |port| -%>
 [tcp://:<%= port['port_num'] %>]
   <% port['config'].each_pair do |name, value| -%>
 <%= name %> = <%= value %>
   <% end -%>
+<% end -%>
+<% end -%>
+
+<% unless @inputs_conf['inputs'].nil? %>
+<% @inputs_conf['inputs'].each do |input| -%>
+[<%= input['input_num'] %>]
+  <% input['config'].each_pair do |name, value| -%>
+<%= name %> = <%= value %>
+  <% end -%>
+<% end -%>
 <% end -%>

--- a/templates/default/inputs.conf.erb
+++ b/templates/default/inputs.conf.erb
@@ -12,7 +12,7 @@ host = <%= @inputs_conf['host'] %>
 
 <% unless @inputs_conf['inputs'].nil? %>
 <% @inputs_conf['inputs'].each do |input| -%>
-[<%= input['input_num'] %>]
+[<%= input['input_path'] %>]
   <% input['config'].each_pair do |name, value| -%>
 <%= name %> = <%= value %>
   <% end -%>


### PR DESCRIPTION
### Description

This pull requests add the ability to add inputs beyond the tcp/port type. It has flexibility to use any supported input type as long as the full string header for each stanza such as [monitor://<path>] or [script://<cmd>]

### Issues Resolved

[GH-36]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
