### PR TITLE
Set ownership of web.conf file.

### DIFF
--- a/recipes/setup_ssl.rb
+++ b/recipes/setup_ssl.rb
@@ -42,6 +42,8 @@ end
 template "#{splunk_dir}/etc/system/local/web.conf" do
   source 'system-web.conf.erb'
   variables ssl_options
+  owner node['splunk']['user']['username']
+  group node['splunk']['user']['username']
   notifies :restart, 'service[splunk]'
 end
 


### PR DESCRIPTION
Signed-off-by: qubitrenegade <qubitrenegade@gmail.com>

### Description

This change sets the user and owner of the web.conf file based on the node attribute `node['splunk']['user']['username']`.  This is the method used to set owner/group on `file "#{splunk_dir}/etc/auth/splunkweb/#{ssl_options['keyfile']}"` in the same recipe.

### Issues Resolved

#106

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing. -- N/A not new functionality
- [x] New functionality has been documented in the README if applicable -- N/A
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
