### PR TITLE
If a `splunk_app` is sensitive, the underlying source is as well

### DIFF
--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -42,6 +42,7 @@ class Chef
               source new_resource.cookbook_file
               cookbook new_resource.cookbook
               checksum new_resource.checksum
+              sensitive new_resource.sensitive
               notifies :run, "execute[splunk-install-#{new_resource.app_name}]", :immediately
             end
           elsif new_resource.remote_file
@@ -49,6 +50,7 @@ class Chef
             remote_file app_package do
               source new_resource.remote_file
               checksum new_resource.checksum
+              sensitive new_resource.sensitive
               notifies :run, "execute[splunk-install-#{new_resource.app_name}]", :immediately
             end
           elsif new_resource.remote_directory
@@ -56,6 +58,7 @@ class Chef
             remote_directory app_dir do
               source new_resource.remote_directory
               cookbook new_resource.cookbook
+              sensitive new_resource.sensitive
               notifies :restart, 'service[splunk]', :immediately
             end
           else


### PR DESCRIPTION
Signed-off-by: Joe Nuspl <nuspl@nvwls.com>

### Description

If `splunk_app` is marked as sensitive, the underlying source should also be sensitive.

### Issues Resolved

None

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
