### PR TITLE
Fixes #50 - allows installing splunk and splunkforwarder from local OS package manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 3.1.0 (TBD)
+- Fixes [#50](https://github.com/chef-cookbooks/chef-splunk/issues/50) `splunk_installer` now allows for installing the package bundle from OS package managers by specifying `package_name` and `version`
+
 ## 3.0.0 (2019-10-15)
 
 - This release is brought to you by @haidangwa. Thanks!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
-## 3.1.0 (TBD)
+## 3.1.0 (2019-10-16)
 - Fixes [#50](https://github.com/chef-cookbooks/chef-splunk/issues/50) `splunk_installer` now allows for installing the package bundle from OS package managers by specifying `package_name` and `version`
 
 ## 3.0.0 (2019-10-15)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-splunk
 # Attributes:: default
 #
-# Copyright:: 2014-2016, Chef Software, Inc.
+# Copyright:: 2014-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,16 +87,21 @@ default['splunk']['inputs_conf']['ports'] = []
 # because we don't want to rely on automagic.
 default['splunk']['user']['home'] = '/opt/splunk' if node['splunk']['is_server']
 
-default['splunk']['server']['runasroot'] = true
-
 default['splunk']['splunk_servers'] = []
 
-default['splunk']['forwarder']['url'] = value_for_platform_family(
-  %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/universalforwarder/releases/6.6.0/linux/splunkforwarder-6.6.0-1c4f3bbe1aea-linux-2.6-x86_64.rpm',
-  ['debian'] => 'https://download.splunk.com/products/universalforwarder/releases/6.6.0/linux/splunkforwarder-6.6.0-1c4f3bbe1aea-linux-2.6-amd64.deb'
-)
+default['splunk']['forwarder'] = {
+  'url' => value_for_platform_family(
+    %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/universalforwarder/releases/6.6.0/linux/splunkforwarder-6.6.0-1c4f3bbe1aea-linux-2.6-x86_64.rpm',
+    ['debian'] => 'https://download.splunk.com/products/universalforwarder/releases/6.6.0/linux/splunkforwarder-6.6.0-1c4f3bbe1aea-linux-2.6-amd64.deb'
+  ),
+  'version' => '6.6.0',
+}
 
-default['splunk']['server']['url'] = value_for_platform_family(
-  %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/splunk/releases/6.6.0/linux/splunk-6.6.0-1c4f3bbe1aea-linux-2.6-x86_64.rpm',
-  ['debian'] => 'https://download.splunk.com/products/splunk/releases/6.6.0/linux/splunk-6.6.0-1c4f3bbe1aea-linux-2.6-amd64.deb'
-)
+default['splunk']['server'] = {
+  'runasroot' => true,
+  'url' => value_for_platform_family(
+    %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/splunk/releases/6.6.0/linux/splunk-6.6.0-1c4f3bbe1aea-linux-2.6-x86_64.rpm',
+    ['debian'] => 'https://download.splunk.com/products/splunk/releases/6.6.0/linux/splunk-6.6.0-1c4f3bbe1aea-linux-2.6-amd64.deb'
+  ),
+  'version' => '6.6.0',
+}

--- a/attributes/upgrade.rb
+++ b/attributes/upgrade.rb
@@ -15,8 +15,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 # assumes x86_64 only (is there any reason to test i386 anymore?)
+# the `server_url` and `forwarder_url` is deprecated, but kept here for
+# backwards-compatibility
 default['splunk']['upgrade']['server_url'] = value_for_platform_family(
   %w(rhel fedora amazon) => 'https://download.splunk.com/products/splunk/releases/7.3.2/linux/splunk-7.3.2-c60db69f8e32-linux-2.6-x86_64.rpm',
   ['debian'] => 'https://download.splunk.com/products/splunk/releases/7.3.2/linux/splunk-7.3.2-c60db69f8e32-linux-2.6-amd64.deb'
@@ -26,3 +28,15 @@ default['splunk']['upgrade']['forwarder_url'] = value_for_platform_family(
   %w(rhel fedora amazon) => 'https://download.splunk.com/products/universalforwarder/releases/7.3.2/linux/splunkforwarder-7.3.2-c60db69f8e32-linux-2.6-x86_64.rpm',
   ['debian'] => 'https://download.splunk.com/products/universalforwarder/releases/7.3.2/linux/splunkforwarder-7.3.2-c60db69f8e32-linux-2.6-amd64.deb'
 )
+
+# as of v3.0.1, this structure was introduced to stay in similar structure to
+# node['splunk']['server'] when specifying URL and version attributes
+default['splunk']['server']['upgrade'] = {
+  'url' => node['splunk']['upgrade']['server_url'],
+  'version' => '7.3.2',
+}
+
+default['splunk']['forwarder']['upgrade'] = {
+  'url' => node['splunk']['upgrade']['forwarder_url'],
+  'version' => '7.3.2',
+}

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -37,7 +37,7 @@ def svc_command(action = 'start')
   unless license_accepted?
     Chef::Log.fatal('You did not accept the license (set node["splunk"]["accept_license"] to true)')
     Chef::Log.fatal('Splunk is stopped and cannot be restarted until the license is accepted!')
-    raise 'Failed to upgrade'
+    raise "Failed to #{action}"
   end
 
   command = "#{splunk_cmd} #{action} --answer-yes --no-prompt --accept-license"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '3.0.0'
+version '3.1.0'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/install_forwarder.rb
+++ b/recipes/install_forwarder.rb
@@ -19,4 +19,5 @@
 
 splunk_installer 'splunkforwarder' do
   url node['splunk']['forwarder']['url']
+  version node['splunk']['forwarder']['version']
 end

--- a/recipes/install_server.rb
+++ b/recipes/install_server.rb
@@ -19,4 +19,5 @@
 
 splunk_installer 'splunk' do
   url node['splunk']['server']['url']
+  version node['splunk']['server']['version']
 end

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -28,5 +28,6 @@ url_type = node['splunk']['is_server'] == true ? 'server' : 'forwarder'
 
 splunk_installer "#{splunk_package} upgrade" do
   action :upgrade
-  url node['splunk']['upgrade']["#{url_type}_url"]
+  url node['splunk'][url_type]['upgrade']['url']
+  version node['splunk'][url_type]['upgrade']['version']
 end

--- a/spec/recipes/install_forwarder_spec.rb
+++ b/spec/recipes/install_forwarder_spec.rb
@@ -31,6 +31,15 @@ describe 'chef-splunk::install_forwarder' do
         chef_run.converge(described_recipe)
         expect(chef_run).to run_splunk_installer('splunkforwarder').with(url: url)
       end
+
+      context 'install from package manager' do
+        it 'should install splunk forwarder from local repo' do
+          chef_run.node.force_default['splunk']['server']['url'] = ''
+          chef_run.node.force_default['splunk']['forwarder']['version'] = '6.6.0'
+          chef_run.converge(described_recipe)
+          expect(chef_run).to run_splunk_installer('splunkforwarder').with(version: '6.6.0')
+        end
+      end
     end
   end
 end

--- a/spec/recipes/install_server_spec.rb
+++ b/spec/recipes/install_server_spec.rb
@@ -31,6 +31,15 @@ describe 'chef-splunk::install_server' do
         chef_run.converge(described_recipe)
         expect(chef_run).to run_splunk_installer('splunk').with(url: url)
       end
+
+      context 'install from package manager' do
+        it 'should install splunk forwarder from local repo' do
+          chef_run.node.force_default['splunk']['server']['url'] = ''
+          chef_run.node.force_default['splunk']['server']['version'] = '6.6.0'
+          chef_run.converge(described_recipe)
+          expect(chef_run).to run_splunk_installer('splunk').with(version: '6.6.0')
+        end
+      end
     end
   end
 end

--- a/spec/recipes/setup_ssl_spec.rb
+++ b/spec/recipes/setup_ssl_spec.rb
@@ -1,18 +1,6 @@
 require 'spec_helper'
 
 describe 'chef-splunk::setup_ssl' do
-  let(:certs) do
-    {
-      'splunk_certificates' => {
-        'id' => 'splunk_certificates',
-        'data' => {
-          'self-signed.example.com.key' => '-----BEGIN RSA PRIVATE KEY-----',
-          'self-signed.example.com.crt' => '-----BEGIN CERTIFICATE-----',
-        },
-      },
-    }
-  end
-
   context 'ssl enabled' do
     context 'default webui port' do
       let(:chef_run) do
@@ -22,7 +10,7 @@ describe 'chef-splunk::setup_ssl' do
           node.force_default['dev_mode'] = true
           node.force_default['splunk']['accept_license'] = true
           # Populate mock certs data into Chef server
-          server.create_data_bag('vault', certs)
+          create_data_bag_item(server, 'vault', 'splunk_certificates')
         end.converge(described_recipe)
       end
 
@@ -78,7 +66,7 @@ describe 'chef-splunk::setup_ssl' do
           node.force_default['dev_mode'] = true
           node.force_default['splunk']['web_port'] = '7777'
           # Populate mock certs data into Chef server
-          server.create_data_bag('vault', certs)
+          create_data_bag_item(server, 'vault', 'splunk_certificates')
         end.converge(described_recipe)
       end
 

--- a/spec/recipes/upgrade_spec.rb
+++ b/spec/recipes/upgrade_spec.rb
@@ -1,35 +1,40 @@
 require 'spec_helper'
 
 describe 'chef-splunk::upgrade' do
-  context 'is server' do
-    let(:url) { 'http://splunk.example.com/server/package437.deb' }
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-        node.force_default['splunk']['upgrade_enabled'] = true
-        node.force_default['splunk']['accept_license'] = true
-        node.force_default['splunk']['upgrade']['server_url'] = url
-        node.force_default['splunk']['is_server'] = true
-      end.converge(described_recipe)
-    end
+  let(:url) { 'http://splunk.example.com/server/package437.deb' }
 
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+      node.force_default['splunk']['upgrade_enabled'] = true
+      node.force_default['splunk']['accept_license'] = true
+      node.force_default['splunk']['server']['upgrade']['url'] = url
+    end
+  end
+
+  context 'is server' do
     it 'ran the splunk installer to upgrade' do
+      chef_run.node.force_default['splunk']['is_server'] = true
+      chef_run.node.force_default['splunk']['server']['upgrade']['url'] = url
+      chef_run.converge(described_recipe)
       expect(chef_run).to upgrade_splunk_installer('splunk upgrade').with(url: url)
     end
   end
 
   context 'is not server' do
-    let(:url) { 'http://splunk.example.com/splunkforwarder/package437.deb' }
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-        node.force_default['splunk']['upgrade_enabled'] = true
-        node.force_default['splunk']['accept_license'] = true
-        node.force_default['splunk']['upgrade']['forwarder_url'] = url
-        node.force_default['splunk']['is_server'] = false
-      end.converge(described_recipe)
-    end
-
     it 'ran the splunk installer to upgrade forwarder' do
+      chef_run.node.force_default['splunk']['is_server'] = false
+      chef_run.node.force_default['splunk']['forwarder']['upgrade']['url'] = url
+      chef_run.converge(described_recipe)
       expect(chef_run).to upgrade_splunk_installer('splunkforwarder upgrade').with(url: url)
+    end
+  end
+
+  context 'upgrade from package manager' do
+    it 'to specified version' do
+      chef_run.node.force_default['splunk']['is_server'] = false
+      chef_run.node.force_default['splunk']['forwarder']['upgrade']['url'] = ''
+      chef_run.converge(described_recipe)
+      expect(chef_run).to upgrade_splunk_installer('splunkforwarder upgrade').with(version: '7.3.2')
     end
   end
 end


### PR DESCRIPTION
### Description

Allows installing splunk and splunk forwarder packages from local OS package managers. End users must have their package managers configured prior to running this cookbook, as configuration of their package management system is outside the scope of this cookbook.

### Issues Resolved

#50 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
