### PR TITLE
chefspec fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 3.2.0 (2019-1209)
+- Fixed logic that checks whether a port is listening when enabling splunk ports
+- in `chef-splunk::client`, do not install the forwarder if the server config is being installed
+  on a splunkd server
+- adds helper method: `#is_server?` that will return true when the chef node is a splunkd server
+
 ## 3.1.1 (2019-12-05)
 
 - Fixes [#125](https://github.com/chef-cookbooks/chef-splunk/issues/125) adds conditional expressions when `node['splunk']['setup_auth']`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
-## 3.2.0 (2019-1209)
+## 3.2.0 (TBD)
 - Fixed logic that checks whether a port is listening when enabling splunk ports
 - in `chef-splunk::client`, do not install the forwarder if the server config is being installed
   on a splunkd server
-- adds helper method: `#is_server?` that will return true when the chef node is a splunkd server
+- adds helper method: `#server?` that will return true if the chef node is a splunkd server
+- adds helper method: `#port_open?` that will return true if the local node has a specified port open
 
 ## 3.1.1 (2019-12-05)
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -188,7 +188,7 @@ suites:
         is_server: true
         accept_license: true
         ssl_options:
-          enable_ssl: true
+          enable_ssl: false
 
   - name: server-runas-splunk
     run_list:
@@ -201,8 +201,8 @@ suites:
         is_server: true
         accept_license: true
         ssl_options:
-          enable_ssl: true
-        web_port: 8443
+          enable_ssl: false
+        web_port: 80
 
   - name: server-cluster-master
     run_list:
@@ -220,7 +220,7 @@ suites:
           replication_factor: 5
           search_factor: 3
         ssl_options:
-          enable_ssl: true
+          enable_ssl: false
 
   - name: server-shcluster-member
     run_list:
@@ -235,8 +235,8 @@ suites:
         shclustering:
           enabled: true
         ssl_options:
-          enable_ssl: true
-        web_port: 8443
+          enable_ssl: false
+        web_port: 80
 
   - name: disabled
     run_list:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,6 +10,13 @@ provisioner:
     dev_mode: true
     splunk:
       accept_license: true
+      enable_ssl: false
+      ssl_options:
+        enableSplunkWebSSL: 0
+        httpport: 8000
+        startwebserver: 1
+
+      web_port: 80
 
 platforms:
   - name: centos-6
@@ -76,8 +83,8 @@ suites:
           runasroot: false
         is_server: true
         ssl_options:
-          enable_ssl: true
-        web_port: 8443
+          enable_ssl: false
+        web_port: 80
 
   - name: server-cluster-master
     run_list:
@@ -106,8 +113,8 @@ suites:
         shclustering:
           enabled: true
         ssl_options:
-          enable_ssl: true
-        web_port: 8443
+          enable_ssl: false
+        web_port: 80
 
   - name: disabled
     run_list:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -94,3 +94,8 @@ end
 def license_accepted?
   node['splunk']['accept_license'] == true
 end
+
+# a splunkd instance is either a splunk client (runs universal forwarder only) or a complete server
+def is_server?
+  node['splunk']['is_server'] == true
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '3.1.1'
+version '3.2.0'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -21,7 +21,7 @@
 # server (with node['splunk']['is_server'] true). The recipes can be
 # used on their own composed in your own wrapper cookbook or role.
 include_recipe 'chef-splunk::user'
-include_recipe 'chef-splunk::install_forwarder' unless is_server?
+include_recipe 'chef-splunk::install_forwarder' unless server?
 
 splunk_servers = search(
   :node,
@@ -31,13 +31,13 @@ splunk_servers = search(
 end
 
 server_list = if !(node['splunk']['server_list'].nil? || node['splunk']['server_list'].empty?)
-  # fallback to statically defined server list as alternative to search
-  node['splunk']['server_list']
-else
-  splunk_servers.map do |s|
-    "#{s['fqdn'] || s['ipaddress']}:#{s['splunk']['receiver_port']}"
-  end.join(', ')
-end
+                # fallback to statically defined server list as alternative to search
+                node['splunk']['server_list']
+              else
+                splunk_servers.map do |s|
+                  "#{s['fqdn'] || s['ipaddress']}:#{s['splunk']['receiver_port']}"
+                end.join(', ')
+              end
 
 # during an initial install, the start/restart commands must deal with accepting
 # the license. So, we must ensure the service[splunk] resource

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef-splunk
 # Recipe:: client
 #
-# Copyright:: 2014-2016, Chef Software, Inc.
+# Copyright:: 2014-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 # server (with node['splunk']['is_server'] true). The recipes can be
 # used on their own composed in your own wrapper cookbook or role.
 include_recipe 'chef-splunk::user'
-include_recipe 'chef-splunk::install_forwarder'
+include_recipe 'chef-splunk::install_forwarder' unless is_server?
 
 splunk_servers = search(
   :node,
@@ -30,12 +30,14 @@ splunk_servers = search(
   a.name <=> b.name
 end
 
-server_list = splunk_servers.map do |s|
-  "#{s['fqdn'] || s['ipaddress']}:#{s['splunk']['receiver_port']}"
-end.join(', ')
-
-# fallback to statically defined server list as alternative to search
-server_list = node['splunk']['server_list'] if server_list.empty?
+server_list = if !(node['splunk']['server_list'].nil? || node['splunk']['server_list'].empty?)
+  # fallback to statically defined server list as alternative to search
+  node['splunk']['server_list']
+else
+  splunk_servers.map do |s|
+    "#{s['fqdn'] || s['ipaddress']}:#{s['splunk']['receiver_port']}"
+  end.join(', ')
+end
 
 # during an initial install, the start/restart commands must deal with accepting
 # the license. So, we must ensure the service[splunk] resource

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -55,7 +55,7 @@ execute 'enable-splunk-receiver-port' do
     begin
       ::TCPSocket.new(node['ipaddress'], node['splunk']['receiver_port'])
     rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      false
+      true
     end
   end
 end

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -23,8 +23,8 @@ unless node['splunk']['upgrade_enabled']
   raise 'Failed to upgrade'
 end
 
-splunk_package = node['splunk']['is_server'] == true ? 'splunk' : 'splunkforwarder'
-url_type = node['splunk']['is_server'] == true ? 'server' : 'forwarder'
+splunk_package = is_server? ? 'splunk' : 'splunkforwarder'
+url_type = is_server? ? 'server' : 'forwarder'
 
 splunk_installer "#{splunk_package} upgrade" do
   action :upgrade

--- a/recipes/upgrade.rb
+++ b/recipes/upgrade.rb
@@ -23,8 +23,8 @@ unless node['splunk']['upgrade_enabled']
   raise 'Failed to upgrade'
 end
 
-splunk_package = is_server? ? 'splunk' : 'splunkforwarder'
-url_type = is_server? ? 'server' : 'forwarder'
+splunk_package = server? ? 'splunk' : 'splunkforwarder'
+url_type = server? ? 'server' : 'forwarder'
 
 splunk_installer "#{splunk_package} upgrade" do
   action :upgrade

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -17,14 +17,17 @@ describe 'chef-splunk::server' do
 
   before(:each) do
     allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_return(true)
-    stub_command("/opt/splunk/bin/splunk enable listen 9997 -auth 'admin:notarealpassword'").and_return(true)
-    # Stub TCP Socket to immediately fail connection to 9997 and raise error without waiting for entire default timeout
-    allow(TCPSocket).to receive(:new).with(anything, '9997') { raise Errno::ETIMEDOUT }
+    allow_any_instance_of(Chef::Recipe).to receive(:current_mgmt_port).and_return('8089')
   end
 
   context 'default settings' do
+    let(:chef_run) do
+      chef_run_init.converge(described_recipe)
+    end
+
     before(:each) do
-      stub_command("/opt/splunk/bin/splunk show splunkd-port -auth 'admin:notarealpassword' | grep ': 8089'").and_return('Splunkd port: 8089')
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_return(true)
+      allow_any_instance_of(Chef::Resource).to receive(:current_mgmt_port).and_return('8089')
     end
 
     it 'does not update splunkd management port' do
@@ -33,20 +36,33 @@ describe 'chef-splunk::server' do
 
     it 'enables receiver port' do
       expect(chef_run).to run_execute('enable-splunk-receiver-port').with(
-        'command' => "/opt/splunk/bin/splunk enable listen 9997 -auth 'admin:notarealpassword'"
+        command: "/opt/splunk/bin/splunk enable listen 9997 -auth 'admin:notarealpassword'",
+        sensitive: true
       )
     end
   end
 
   context 'custom management port' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node, server|
+        node.force_default['dev_mode'] = true
+        node.force_default['splunk']['is_server'] = true
+        node.force_default['splunk']['accept_license'] = true
+        node.force_default['splunk']['mgmt_port'] = '9089'
+        # Populate mock vault data bag to the server
+        create_data_bag_item(server, 'vault', 'splunk__default')
+      end.converge(described_recipe)
+    end
+
     before(:each) do
-      stub_command("/opt/splunk/bin/splunk show splunkd-port -auth 'admin:notarealpassword' | grep ': 9089'").and_return(false)
-      chef_run_init.node.force_default['splunk']['mgmt_port'] = '9089'
+      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_return(true)
+      allow_any_instance_of(Chef::Resource).to receive(:current_mgmt_port).and_return('8089')
     end
 
     it 'updates splunkd management port' do
       expect(chef_run).to run_execute('update-splunk-mgmt-port').with(
-        'command' => "/opt/splunk/bin/splunk set splunkd-port 9089 -auth 'admin:notarealpassword'"
+        command: "/opt/splunk/bin/splunk set splunkd-port 9089 -auth 'admin:notarealpassword'",
+        sensitive: true
       )
     end
 
@@ -57,7 +73,8 @@ describe 'chef-splunk::server' do
 
     it 'enables receiver port' do
       expect(chef_run).to run_execute('enable-splunk-receiver-port').with(
-        'command' => "/opt/splunk/bin/splunk enable listen 9997 -auth 'admin:notarealpassword'"
+        command: "/opt/splunk/bin/splunk enable listen 9997 -auth 'admin:notarealpassword'",
+        sensitive: true
       )
     end
   end

--- a/test/integration/server-runas-root/serverspec/server_spec.rb
+++ b/test/integration/server-runas-root/serverspec/server_spec.rb
@@ -6,8 +6,8 @@ describe 'chef-splunk::server should run as "root" user' do
   end
 end
 
-describe 'chef-splunk::server should listen on web_port 443' do
-  describe port(443) do
+describe 'chef-splunk::server should listen on web_port 80' do
+  describe port(80) do
     it { should be_listening.with('tcp') }
   end
 end

--- a/test/integration/server-runas-splunk/serverspec/server_spec.rb
+++ b/test/integration/server-runas-splunk/serverspec/server_spec.rb
@@ -6,8 +6,8 @@ describe 'chef-splunk::server should run as "splunk" user' do
   end
 end
 
-describe 'chef-splunk::server should listen on web_port 8443' do
-  describe port(8443) do
+describe 'chef-splunk::server should listen on web_port 80' do
+  describe port(80) do
     it { should be_listening.with('tcp') }
   end
 end


### PR DESCRIPTION
### Description

    - fixes chefspec
    - adds helper methods: `#current_mgmt_port` and `#port_open?`
    - rename helper method: `#is_server?` is now `#server?`


### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
