### PR TITLE
bugfix and/or update the splunk_app resource/provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib/bundler/man
 pkg
 rdoc
 spec/reports
+spec/examples.txt
 test/tmp
 test/version_tmp
 tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 4.1.0 (TBD)
+- Adds attribute `node['splunk']['shclustering']['app_dir']` to take the place of local ruby
+  variable to set the search head clustering application directory.
+- Uses the splunk CLI to add search head cluster members instead of the app server.conf file
+  to ensure members are properly added. SH cluster members wait for the captain to converge.
+- Search Head Captains will initialize as a search head cluster member and then bootstrap themselves
+- Improves idempotent addition of search head cluster members
+- Fixes issue [#137](https://github.com/chef-cookbooks/chef-splunk/issues/137)
+    - Adds logic to skip any initialization or bootstrapping of search head cluster resources.
+- Fixes issue [#138](https://github.com/chef-cookbooks/chef-splunk/issues/138)
+    - Adds a new property to the `splunk_app` resource, called `template_variables`
+- Fixes issue [#139](https://github.com/chef-cookbooks/chef-splunk/issues/139)
+    - Adds `cookbook` property to the template declared in the `splunk_app` provider
+- Fixes issue [#140](https://github.com/chef-cookbooks/chef-splunk/issues/140)
+    - Adds back resource actions: :enable, :disable, :install, :remove
+- Fixes issue [#141](https://github.com/chef-cookbooks/chef-splunk/issues/141)
+    - `app_dir` property was added to the `splunk_app` resource
+- Integrates a search head cluster to a single or multisite indexer cluster
+- Adds helper method `#add_shcluster_member?` to indicate whether a search head cluster member needs to
+  be added to the search head cluster
+- Adds support for Hash when providing the `templates` property to the `splunk_app` resource
+- Adds `:update` action to `splunk_app` resource
+
 ## 4.0.5 (2020-01-15)
 - Adds a state file and a guard that ensures the `template[user-seed.conf]` resource is idempotent
 - Fixes the shcluster-captain bootstrap command where `--servers_list` was provided a semi-colon separated

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ clustering in the `setup_clustering` recipe:
 * `node['splunk']['clustering']['replication_port']`: The replication port
   of the cluster peer member. Only valid when `node['splunk']['clustering']['mode']='slave'`.
   Defaults to 9887.
+* `node['splunk']['clustering']['mgmt_uri']` (Default: https://fqdn:8089)
+  This attribute is for the indexer cluster members and cluster master. The cluster master
+  will set this node attribute to itself, while all cluster members will perform a chef search
+  to get the value from the cluster master's node data.
 
 * For single-site clustering (`node['splunk']['clustering']['num_sites']` = 1):
   * `node['splunk']['clustering']['replication_factor']`: The replication factor

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ clustering in the `setup_shclustering` recipe:
 
 * `node['splunk']['shclustering']`: A hash of search head clustering configurations
   used in the `setup_shclustering` recipe
+* `node['splunk']['shclustering']['app_dir']`: the path where search head clustering configuration will
+  be installed (Default: /opt/splunk/etc/apps/0_autogen_shcluster_config)
 * `node['splunk']['shclustering']['enabled']`: Whether to enable search head clustering,
   must be set to `true` to use the `setup_shclustering` recipe. Defaults to `false`,
   must be a boolean literal `true` or `false`.
@@ -331,10 +333,83 @@ must be set explicitly elsewhere on the node(s).
 
 ## Custom Resources
 
+### splunk_app
+
+This resource will install a Splunk app or deployment app into the appropriate locations
+on a Splunk Enterprise server. Some custom "apps" simply install with a few files to override
+default Splunk settings. The latter is desirable for maintaining settings after an upgrade of the
+Splunk Enterprise server software.
+
+#### Actions
+* `:enable`: Enables a Splunk app after it has been disabled or newly installed
+* `:disable`: Disables a Splunk app and leaves it installed
+* `:install`: Installs a Splunk app or deployment app
+* `:update`: Updates a Splunk app that was previously installed. If the app is not installed, this action will
+  go ahead and install the app as if `:install` was specified.
+* `:remove`: Completely removes a Splunk app or deployment app from the Splunk Enterprise server
+
+#### Properties
+# TODO: document the rest of the splunk_app properties
+
+* `cookbook`: Used in conjunction with the `templates` property, this specifies the cookbook where templates will be sourced
+
+* `templates`: This is either an array of template names or a Hash consisting of a target destination path and template names
+  For example: `['server.conf.erb']` or `{ 'etc/deployment-apps' => 'server.conf.erb' }`.
+
+* `template_variables`: This is a Hash with embedded Hash to specify variables that can be passed into the templates keyed by
+  the name of the template, matching the template names in `templates` property above. The format of this Hash is such that
+  a `default` Hash can specify variables/values passed to all templates or it can specify different variables/values for any and all
+  templates.
+
+  For example, this will pass the default Hash of variables/values into all of the templates, but the `foo.erb` template will
+  be fed a unique Hash of variables/values.
+  ```ruby
+  splunk_app 'my app' do
+    templates %w(foo.erb bar.erb server.conf.erb app.conf.erb outputs.conf.erb)
+    template_variables {
+      {
+        'default' => { 'var1' => 'value1', 'var2' => 'value2' },
+        'foo.erb' => { 'x' => 'snowflake template' }
+      }
+    }
+  end
+  ```
+
+
+#### Examples
+
+Install and enable a deployment client configuration that overrides default Splunk Enterprise configurations
+
+- Given a wrapper cookbook called MyDeploymentClientBase with a folder structure as below:
+```
+MyDeploymentClientBase
+    /templates
+        /MyDeploymentClientBase
+            deploymentclient.conf.erb
+```
+
+```ruby
+splunk_auth_info = data_bag_item('vault', "splunk_#{node.chef_environment}")['auth']
+
+splunk_app 'MyDeploymentClientBase' do
+  splunk_auth splunk_auth_info
+  templates ['deploymentclient.conf.erb']
+  cookbook 'MyDeploymentClientBase'
+  action %i(install enable)
+end
+```
+
+The Splunk Enterprise server will have a filesystem created, as follows:
+```
+/opt/splunk/etc/apps/MyDeploymentClientBase/local/deploymentclient.conf
+```
+
+
+
 ### splunk_installer
 
 The Splunk Enterprise and Splunk Universal Forwarder package
-installation is the same save the name of the package and the URL to
+installation is the same, save for the name of the package and the URL to
 download. This custom resource abstracts the package installation to a
 common baseline. Any new platform installation support should be added
 by modifying the custom resource as appropriate. One goal of this

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,7 @@ default['splunk']['ssl_options'] = {
 default['splunk']['clustering'] = {
   'enabled' => false,
   'num_sites' => 1,   # multisite is true if num_sites > 1
+  'mgmt_uri' => "https://#{node['fqdn']}:8089",
   'mode' => 'master', # master|slave|searchhead
   'replication_port' => '9887',
   # Following two params only applicable if num_sites = 1 (multisite is false)
@@ -58,13 +59,14 @@ default['splunk']['clustering'] = {
 }
 
 default['splunk']['shclustering'] = {
+  'app_dir' => '/opt/splunk/etc/apps/0_autogen_shcluster_config',
+  'deployer_url' => '',
   'enabled' => false,
-  'mode' => 'member', # member|captain|deployer
   'label' => 'shcluster1',
+  'mgmt_uri' => "https://#{node['fqdn']}:8089",
+  'mode' => 'member', # member|captain|deployer
   'replication_factor' => 3,
   'replication_port' => 9900,
-  'deployer_url' => '',
-  'mgmt_uri' => "https://#{node['fqdn']}:8089",
   'shcluster_members' => [],
 }
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'stable' %>
   chef_license: accept-no-persist
 
 transport:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -239,7 +239,7 @@ suites:
 
   - name: upgrade_server
     run_list:
-      - recipe[chef-splunk::server]
+      - recipe[chef-splunk::default]
       - recipe[chef-splunk::upgrade]
     attributes:
       splunk:

--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -1,6 +1,7 @@
 #
 # Author: Joshua Timberman <joshua@chef.io>
-# Copyright:: 2014-2019, Chef Software, Inc <legal@chef.io>
+# Contributor: Dang H. Nguyen <dang.nguyen@disney.com>
+# Copyright:: 2014-2020, Chef Software, Inc <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,62 +29,151 @@ class Chef
 
       action :install do
         splunk_service
-        install_dependencies unless new_resource.app_dependencies.empty?
-        unless app_installed?
-          if new_resource.cookbook_file
-            app_package = local_file(new_resource.cookbook_file)
-            cookbook_file app_package do
-              source new_resource.cookbook_file
-              cookbook new_resource.cookbook
-              checksum new_resource.checksum
-              owner splunk_runas_user
-              group splunk_runas_user
-              notifies :run, "execute[splunk-install-#{new_resource.app_name}]", :immediately
-            end
-          elsif new_resource.remote_file
-            app_package = local_file(new_resource.remote_file)
-            remote_file app_package do
-              source new_resource.remote_file
-              checksum new_resource.checksum
-              owner splunk_runas_user
-              group splunk_runas_user
-              notifies :run, "execute[splunk-install-#{new_resource.app_name}]", :immediately
-            end
-          elsif new_resource.remote_directory
-            app_package = app_dir
-            remote_directory app_dir do
-              source new_resource.remote_directory
-              cookbook new_resource.cookbook
-              owner splunk_runas_user
-              group splunk_runas_user
-              files_owner splunk_runas_user
-              files_group splunk_runas_user
-              notifies :restart, 'service[splunk]', :immediately
-            end
-          else
-            raise "Could not find an installation source for splunk_app[#{new_resource.app_name}]"
-          end
+        setup_app_dir
+        install
+        custom_app_configs
+      end
 
-          dir = app_dir
-
-          execute "splunk-install-#{new_resource.app_name}" do
-            sensitive true
-            command "#{splunk_cmd} install app #{app_package} -auth #{splunk_auth(new_resource.splunk_auth)}"
-            not_if { ::File.exist?("#{dir}/default/app.conf") }
-          end
+      action :update do
+        splunk_service
+        setup_app_dir
+        if app_installed?
+          install(true)
+        else
+          install
         end
+        custom_app_configs
+      end
 
-        directory "#{app_dir}/local" do
+      action :remove do
+        dir = app_dir # this grants chef resources access to the private `#app_dir`
+
+        splunk_service
+        directory dir do
+          action :delete
           recursive true
-          mode '755'
-          owner splunk_runas_user
-          group splunk_runas_user
+          notifies :restart, 'service[splunk]'
+        end
+      end
+
+      action :enable do
+        # delay in case an install was previously executed prior to enable, so
+        # splunk can catch up
+        5.times do |i|
+          break if app_installed?
+          ::Chef::Log.info "Waiting for Splunk App Install: retries #{4 - i}/5 left"
+          sleep 30
         end
 
-        if new_resource.templates
+        if app_enabled?
+          ::Chef::Log.debug "#{new_resource.app_name} is enabled"
+          return
+        end
+
+        splunk_service
+        execute "splunk-enable-#{new_resource.app_name}" do
+          sensitive false
+          command "#{splunk_cmd} enable app #{new_resource.app_name} -auth #{splunk_auth(new_resource.splunk_auth)}"
+          notifies :restart, 'service[splunk]'
+        end
+      end
+
+      action :disable do
+        return unless app_enabled?
+        splunk_service
+        execute "splunk-disable-#{new_resource.app_name}" do
+          sensitive false
+          command "#{splunk_cmd} disable app #{new_resource.app_name} -auth #{splunk_auth(new_resource.splunk_auth)}"
+          not_if { ::File.exist?("#{splunk_dir}/etc/disabled-apps/#{new_resource.app_name}") }
+          notifies :restart, 'service[splunk]'
+        end
+      end
+
+      private
+
+      def setup_app_dir
+        dir = app_dir # this grants chef resources access to the private `#app_dir`
+
+        install_dependencies unless new_resource.app_dependencies.empty?
+        return if [new_resource.cookbook_file, new_resource.remote_file, new_resource.remote_directory].compact.empty?
+
+        if new_resource.cookbook_file
+          app_package = local_file(new_resource.cookbook_file)
+          cookbook_file app_package do
+            source new_resource.cookbook_file
+            cookbook new_resource.cookbook
+            checksum new_resource.checksum
+            owner splunk_runas_user
+            group splunk_runas_user
+            notifies :run, "execute[splunk-install-#{new_resource.app_name}]", :immediately
+          end
+        elsif new_resource.remote_file
+          app_package = local_file(new_resource.remote_file)
+          remote_file app_package do
+            source new_resource.remote_file
+            checksum new_resource.checksum
+            owner splunk_runas_user
+            group splunk_runas_user
+            notifies :run, "execute[splunk-install-#{new_resource.app_name}]", :immediately
+          end
+        elsif new_resource.remote_directory
+          remote_directory dir do
+            source new_resource.remote_directory
+            cookbook new_resource.cookbook
+            owner splunk_runas_user
+            group splunk_runas_user
+            files_owner splunk_runas_user
+            files_group splunk_runas_user
+            notifies :restart, 'service[splunk]'
+          end
+        end
+      end
+
+      def custom_app_configs
+        dir = app_dir # this grants chef resources access to the private `#app_dir`
+
+        if new_resource.templates.class == Hash
+          # create the templates with destination paths relative to the target app_dir
+          # Hash should be key/value where the key indicates a destination path (including file name),
+          # and value is the name of the template source
+          new_resource.templates.each do |destination, source|
+            directory "#{dir}/#{::File.dirname(destination)}" do
+              recursive true
+              mode '755'
+              owner splunk_runas_user
+              group splunk_runas_user
+            end
+
+            template "#{dir}/#{destination}" do
+              source source
+              cookbook new_resource.cookbook
+              variables new_resource.template_variables['default']
+              owner splunk_runas_user
+              group splunk_runas_user
+              mode '644'
+              notifies :restart, 'service[splunk]'
+            end
+          end
+        else
+          directory "#{dir}/local" do
+            recursive true
+            mode '755'
+            owner splunk_runas_user
+            group splunk_runas_user
+          end
+
           new_resource.templates.each do |t|
-            template "#{app_dir}/local/#{t}" do
+            template_variables = if new_resource.template_variables.key?(t)
+                                   new_resource.template_variables[t]
+                                 else
+                                   new_resource.template_variables['default']
+                                 end
+            t = t.match?(/(\.erb)*/) ? ::File.basename(t, '.erb') : t
+
+            template "#{dir}/local/#{t}" do
               source "#{new_resource.app_name}/#{t}.erb"
+              cookbook new_resource.cookbook
+              variables template_variables
               owner splunk_runas_user
               group splunk_runas_user
               mode '644'
@@ -93,44 +183,22 @@ class Chef
         end
       end
 
-      action :remove do
-        splunk_service
-        directory app_dir do
-          action :delete
-          recursive true
-          owner splunk_runas_user
-          group splunk_runas_user
-          notifies :restart, 'service[splunk]'
+      def install(update = false)
+        dir = app_dir # this grants chef resources access to the private `#app_dir`
+        command = if app_installed? && update == true
+                    "#{splunk_cmd} install app #{dir} -update 1 -auth #{splunk_auth(new_resource.splunk_auth)}"
+                  elsif !app_installed? && update == false
+                    "#{splunk_cmd} install app #{dir} -auth #{splunk_auth(new_resource.splunk_auth)}"
+                  end
+        execute "splunk-install-#{new_resource.app_name}" do
+          sensitive false
+          command command
+          not_if { command.nil? }
         end
       end
-
-      action :enable do
-        unless app_enabled?
-          splunk_service
-          execute "splunk-enable-#{new_resource.app_name}" do
-            sensitive true
-            command "#{splunk_cmd} enable app #{new_resource.app_name} -auth #{splunk_auth(new_resource.splunk_auth)}"
-            notifies :restart, 'service[splunk]'
-          end
-        end
-      end
-
-      action :disable do
-        if app_enabled?
-          splunk_service
-          execute "splunk-disable-#{new_resource.app_name}" do
-            sensitive true
-            command "#{splunk_cmd} disable app #{new_resource.app_name} -auth #{splunk_auth(new_resource.splunk_auth)}"
-            not_if { ::File.exist?("#{splunk_dir}/etc/disabled-apps/#{new_resource.app_name}") }
-            notifies :restart, 'service[splunk]'
-          end
-        end
-      end
-
-      private
 
       def app_dir
-        "#{splunk_dir}/etc/apps/#{new_resource.app_name}"
+        new_resource.app_dir || "#{splunk_dir}/etc/apps/#{new_resource.app_name}"
       end
 
       def local_file(source)
@@ -139,23 +207,33 @@ class Chef
 
       def app_enabled?
         s = shell_out("#{splunk_cmd} display app #{new_resource.app_name} -auth #{splunk_auth(new_resource.splunk_auth)}")
-        s.run_command
-        if s.stdout.empty?
-          false
-        else
-          s.stdout.split[2] == 'ENABLED'
-        end
+        s.exitstatus == 0 && s.stdout.split[2] == 'ENABLED'
       end
 
       def app_installed?
-        ::File.exist?("#{app_dir}/default/app.conf")
+        s = shell_out("#{splunk_cmd} display app #{new_resource.app_name} -auth #{splunk_auth(new_resource.splunk_auth)}")
+        return_val = s.exitstatus == 0 && s.stdout.match?(/^#{new_resource.app_name}/)
+
+        ::Chef::Log.debug s.stdout
+        ::Chef::Log.debug s.stderr
+        ::Chef::Log.debug s.exitstatus
+        ::Chef::Log.debug "return: #{return_val}"
+
+        return_val
       end
 
       def splunk_service
-        service 'splunk' do
-          action :nothing
+        # during an initial install, the start/restart commands must deal with accepting
+        # the license. So, we must ensure the service[splunk] resource
+        # properly deals with the license.
+        edit_resource(:service, 'splunk') do
+          action node['init_package'] == 'systemd' ? %i(start enable) : :start
           supports status: true, restart: true
-          provider Chef::Provider::Service::Init
+          stop_command svc_command('stop')
+          start_command svc_command('start')
+          restart_command svc_command('restart')
+          status_command svc_command('status')
+          provider splunk_service_provider
         end
       end
 

--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -144,10 +144,17 @@ class Chef
               group splunk_runas_user
             end
 
+            # TODO: DRY this handling of template_variables with that of lines 173-188
+            template_variables = if new_resource.template_variables.key?(destination)
+                                   new_resource.template_variables[destination]
+                                 else
+                                   new_resource.template_variables['default']
+                                 end
+
             template "#{dir}/#{destination}" do
               source source
               cookbook new_resource.cookbook
-              variables new_resource.template_variables['default']
+              variables template_variables
               owner splunk_runas_user
               group splunk_runas_user
               mode '644'

--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -145,8 +145,8 @@ class Chef
             end
 
             # TODO: DRY this handling of template_variables with that of lines 173-188
-            template_variables = if new_resource.template_variables.key?(destination)
-                                   new_resource.template_variables[destination]
+            template_variables = if new_resource.template_variables.key?(source)
+                                   new_resource.template_variables[source]
                                  else
                                    new_resource.template_variables['default']
                                  end

--- a/libraries/splunk_app_resource.rb
+++ b/libraries/splunk_app_resource.rb
@@ -1,6 +1,7 @@
 #
 # Author: Joshua Timberman <joshua@chef.io>
-# Copyright:: 2014-2016, Chef Software, Inc <legal@chef.io>
+# Contributor: Dang H. Nguyen <dang.nguyen@disney.com>
+# Copyright:: 2014-2020, Chef Software, Inc <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +24,12 @@ class Chef
       self.resource_name = 'splunk_app'
 
       # Actions correspond to splunk commands pertaining to apps.
+      actions :enable, :disable, :install, :update, :remove
       default_action :enable
       state_attrs :enabled, :installed
 
       attribute :app_name, kind_of: String, name_attribute: true
+      attribute :app_dir, kind_of: String, default: nil
       attribute :remote_file, kind_of: String, default: nil
       attribute :cookbook_file, kind_of: String, default: nil
       attribute :cookbook, kind_of: String, default: nil
@@ -35,6 +38,11 @@ class Chef
       attribute :splunk_auth, kind_of: [String, Array], required: true
       attribute :app_dependencies, kind_of: Array, default: []
       attribute :templates, kind_of: [Array, Hash], default: []
+
+      # template_variables is a Hash referencing
+      # each template named in the templates property, above, with each template having its
+      # unique set of variables and values
+      attribute :template_variables, kind_of: Hash, default: { 'default' => {} }
       attribute :enabled, kind_of: [TrueClass, FalseClass, NilClass], default: false
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '4.0.5'
+version '4.1.0'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -99,4 +99,4 @@ template "#{splunk_dir}/etc/apps/SplunkUniversalForwarder/default/limits.conf" d
 end
 
 include_recipe 'chef-splunk::service'
-include_recipe 'chef-splunk::setup_auth' if node['splunk']['setup_auth']
+include_recipe 'chef-splunk::setup_auth' if setup_auth?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,6 +2,7 @@
 # Cookbook:: chef-splunk
 # Recipe:: default
 #
+# Author: Dang H. Nguyen <dang.nguyen@disney.com>
 # Copyright:: 2014-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +23,12 @@ if disabled?
   Chef::Log.debug('Splunk is disabled on this node.')
   return
 end
+
+# We can rely on loading the chef_vault_item here into the run_state so other
+# recipes don't have to keep going back to the chef server to access the vault/data bag item
+vault_item = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_environment}")
+node.run_state['splunk_auth_info'] = vault_item['auth']
+node.run_state['splunk_secret'] = vault_item['secret']
 
 if server?
   include_recipe 'chef-splunk::server'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ end
 # We can rely on loading the chef_vault_item here into the run_state so other
 # recipes don't have to keep going back to the chef server to access the vault/data bag item
 vault_item = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_environment}")
-node.run_state['splunk_auth_info'] = vault_item['auth']
+node.run_state['splunk_auth_info'] = splunk_auth(vault_item['auth'])
 node.run_state['splunk_secret'] = vault_item['secret']
 
 if server?

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -37,19 +37,21 @@ end
 
 # We can rely on loading the chef_vault_item here, as `setup_auth`
 # above would have failed if there were another issue.
-splunk_auth_info = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_environment}")['auth']
+vault_item = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_environment}")
+node.run_state['splunk_auth_info'] = vault_item['auth']
+node.run_state['splunk_secret'] = vault_item['secret']
 
 execute 'update-splunk-mgmt-port' do
-  command "#{splunk_cmd} set splunkd-port #{node['splunk']['mgmt_port']} -auth '#{splunk_auth_info}'"
+  command "#{splunk_cmd} set splunkd-port #{node['splunk']['mgmt_port']} -auth '#{node.run_state['splunk_auth_info']}'"
   sensitive true
-  not_if { current_mgmt_port(splunk_auth_info) == node['splunk']['mgmt_port'] }
+  not_if { current_mgmt_port(node.run_state['splunk_auth_info']) == node['splunk']['mgmt_port'] }
   notifies :restart, 'service[splunk]'
 end
 
 ruby_block 'enable-splunk-receiver-port' do
   sensitive true
   block do
-    splunk = Mixlib::ShellOut.new("#{splunk_cmd} enable listen #{node['splunk']['receiver_port']} -auth #{splunk_auth_info}")
+    splunk = Mixlib::ShellOut.new("#{splunk_cmd} enable listen #{node['splunk']['receiver_port']} -auth #{node.run_state['splunk_auth_info']}")
     splunk.run_command
     true if splunk.stderr.include?("Configuration for port #{node['splunk']['receiver_port']} already exists")
   end

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -25,8 +25,7 @@ unless setup_auth?
   return
 end
 
-splunk_auth_info = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_environment}")['auth']
-user, pw = splunk_auth_info.split(':')
+user, pw = node.run_state['splunk_auth_info'].split(':')
 
 # during an initial install, the start/restart commands must deal with accepting
 # the license. So, we must ensure the service[splunk] resource
@@ -50,7 +49,7 @@ template 'user-seed.conf' do
   sensitive true
   variables user: user, password: pw
   notifies :restart, 'service[splunk]', :immediately
-  not_if { File.exist?("#{splunk_dir}/etc/system/local/.user-seed.conf") }
+  not_if { ::File.exist?("#{splunk_dir}/etc/system/local/.user-seed.conf") }
 end
 
 file '.user-seed.conf' do

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -25,6 +25,7 @@ unless setup_auth?
   return
 end
 
+include_recipe 'chef-splunk'
 user, pw = node.run_state['splunk_auth_info'].split(':')
 
 # during an initial install, the start/restart commands must deal with accepting

--- a/recipes/setup_shclustering.rb
+++ b/recipes/setup_shclustering.rb
@@ -3,7 +3,8 @@
 # Recipe:: setup_shclustering
 #
 # Author: Ryan LeViseur <ryanlev@gmail.com>
-# Copyright:: (c) 2014-2019, Chef Software, Inc <legal@chef.io>
+# Contributor: Dang H. Nguyen <dang.nguyen@disney.com>
+# Copyright:: (c) 2014-2020, Chef Software, Inc <legal@chef.io>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,43 +37,47 @@ edit_resource(:service, 'splunk') do
   provider splunk_service_provider
 end
 
-passwords = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_environment}")
-splunk_auth_info = passwords['auth']
-shcluster_secret = passwords['secret']
-
+# initialize
 # create app directories to house our server.conf with our shcluster configuration
-shcluster_app_dir = "#{splunk_dir}/etc/apps/0_autogen_shcluster_config"
-
-directory shcluster_app_dir do
+directory node['splunk']['shclustering']['app_dir'] do
   owner splunk_runas_user
   group splunk_runas_user
   mode '755'
+  only_if { node['splunk']['shclustering']['mode'] == 'deployer' }
 end
 
-directory "#{shcluster_app_dir}/local" do
+directory "#{node['splunk']['shclustering']['app_dir']}/local" do
   owner splunk_runas_user
   group splunk_runas_user
   mode '755'
+  only_if { node['splunk']['shclustering']['mode'] == 'deployer' }
 end
 
-template "#{shcluster_app_dir}/local/server.conf" do
-  source 'shclustering/server.conf.erb'
-  mode '600'
-  owner splunk_runas_user
-  group splunk_runas_user
-  variables(
-    shcluster_params: node['splunk']['shclustering'],
-    shcluster_secret: shcluster_secret
-  )
-  sensitive true
-  notifies :restart, 'service[splunk]', :immediately
+# use the internal ec2 hostname for splunk-to-splunk communications
+# this type traffic is usually free in AWS
+node.force_default['splunk']['shclustering']['mgmt_uri'] = "https://#{node['ec2']['local_hostname']}:8089" if node.attribute?('ec2')
+
+if node['splunk']['shclustering']['mode'] == 'deployer'
+  template "#{node['splunk']['shclustering']['app_dir']}/local/server.conf" do
+    source 'shclustering/server.conf.erb'
+    mode '600'
+    owner splunk_runas_user
+    group splunk_runas_user
+    variables(
+      shcluster_params: node['splunk']['shclustering'],
+      shcluster_secret: node.run_state['splunk_secret']
+    )
+    sensitive true
+    notifies :restart, 'service[splunk]', :immediately
+  end
 end
 
-# finish here if the server is the Splunk Search Head deployer; otherwise, continue on
+# quit early for deployers or when a search head member/captain have already been provisioned
 return if node['splunk']['shclustering']['mode'] == 'deployer'
 
-# bootstrap the shcluster and the node as a captain if shclustering mode is set to 'captain'
-shcluster_servers_list = []
+#
+# everything from this point on deal only with search head cluster members and the captain
+#
 
 # search for the fqdn of the search head deployer and set that as the deployer_url
 # if one is not given in the node attributes
@@ -84,40 +89,117 @@ if node['splunk']['shclustering']['deployer_url'].empty?
     splunk_shclustering_label:#{node['splunk']['shclustering']['label']} AND \
     splunk_shclustering_mode:deployer AND \
     chef_environment:#{node.chef_environment}",
-    filter_result: { 'deployer_fqdn' => ['fqdn'] }
-  ).each do |fqdn|
-    node.default['splunk']['shclustering']['deployer_url'] = fqdn
+    filter_result: { 'deployer_mgmt_uri' => %w(splunk shclustering mgmt_uri) }
+  ).each do |result|
+    node.default['splunk']['shclustering']['deployer_url'] = result['deployer_mgmt_uri']
   end
 end
 
+# Primary rule: all captains are members; all members must be initialized before being added to a
+# cluster.
+#
+# Secondary rule: if a captain has been setup and converged, the chef server will have its node data
+# saved and search will return a proper value for the captain. If the captain has not
+# converged, then a shcluster member should only initialize itself and wait until future
+# chef runs to add itself as a member.
+
+# search head cluster member list needed to bootstrap the shcluster captain
+shcluster_servers_list = [node['splunk']['shclustering']['mgmt_uri']]
+
 # unless shcluster members are staticly assigned via the node attribute,
 # try to find the other shcluster members via Chef search
-if node['splunk']['shclustering']['mode'] == 'captain' &&
-   node['splunk']['shclustering']['shcluster_members'].empty?
+# if node['splunk']['shclustering']['mode'] == 'captain' &&
+if node['splunk']['shclustering']['shcluster_members'].empty?
   search(
     :node,
     "\
     splunk_shclustering_enabled:true AND \
     splunk_shclustering_label:#{node['splunk']['shclustering']['label']} AND \
-    chef_environment:#{node.chef_environment}"
+    splunk_shclustering_mode:member AND \
+    chef_environment:#{node.chef_environment}",
+    filter_result: { 'member_mgmt_uri' => %w(splunk shclustering mgmt_uri) }
   ).each do |result|
-    shcluster_servers_list << result['splunk']['shclustering']['mgmt_uri']
+    shcluster_servers_list << result['member_mgmt_uri']
   end
 else
   shcluster_servers_list = node['splunk']['shclustering']['shcluster_members']
 end
 
-execute 'bootstrap-shcluster' do
-  command "#{splunk_cmd} bootstrap shcluster-captain -servers_list '#{shcluster_servers_list.join(',')}' -auth '#{splunk_auth_info}'"
-  sensitive true
-  not_if { ::File.exist?("#{splunk_dir}/etc/.setup_shcluster") }
-  only_if { node['splunk']['shclustering']['mode'] == 'captain' }
-  notifies :restart, 'service[splunk]'
+if shcluster_servers_list.size < 3
+  log 'A minimum of three search head cluster members are required for distributed search. Nothing to do this time.' do
+    level :warn
+  end
+  return
 end
 
-file "#{splunk_dir}/etc/.setup_shcluster" do
-  content "true\n"
-  owner splunk_runas_user
-  group splunk_runas_user
-  mode '600'
+# initialize the member and then quit until the next chef run;
+# this effectively waits until the captain is ready before adding members to the cluster
+execute 'initialize search head cluster member' do
+  sensitive true
+  command "#{splunk_cmd} init shcluster-config -auth '#{node.run_state['splunk_auth_info']}' " \
+    "-mgmt_uri #{node['splunk']['shclustering']['mgmt_uri']} " \
+    "-replication_port #{node['splunk']['shclustering']['replication_port']} " \
+    "-replication_factor #{node['splunk']['shclustering']['replication_factor']} " \
+    "-conf_deploy_fetch_url #{node['splunk']['shclustering']['deployer_url']} " \
+    "-secret #{node.run_state['splunk_secret']} " \
+    "-shcluster_label #{node['splunk']['shclustering']['label']}"
+  notifies :restart, 'service[splunk]', :immediately
+  only_if { init_shcluster_member? }
+end
+
+if shcluster_servers_list.size >= 2 && node['splunk']['shclustering']['mode'] == 'captain'
+  execute 'bootstrap-shcluster-captain' do
+    sensitive true
+    command "#{splunk_cmd} bootstrap shcluster-captain -auth '#{node.run_state['splunk_auth_info']}' " \
+      "-servers_list \"#{shcluster_servers_list.join(',')}\""
+    notifies :restart, 'service[splunk]', :immediately
+    not_if { shcaptain_elected? }
+  end
+elsif shcaptain_elected? && !shcluster_members_ipv4.include?(node['ipaddress'])
+  captain_mgmt_uri = nil
+  search(
+    :node,
+    "\
+    splunk_shclustering_enabled:true AND \
+    splunk_shclustering_label:#{node['splunk']['shclustering']['label']} AND \
+    splunk_shclustering_mode:captain AND \
+    chef_environment:#{node.chef_environment}",
+    filter_result: { 'captain_mgmt_uri' => %w(splunk shclustering mgmt_uri) }
+  ).each { |result| captain_mgmt_uri = result['captain_mgmt_uri'] }
+
+  execute 'add member to search head cluster' do
+    sensitive true
+    command "#{splunk_cmd} add shcluster-member -current_member_uri #{captain_mgmt_uri} -auth '#{node.run_state['splunk_auth_info']}'"
+    only_if { node['splunk']['shclustering']['mode'] == 'member' }
+    notifies :restart, 'service[splunk]'
+  end
+end
+
+cluster_master = { 'mgmt_uri' => nil, 'num_sites' => 1, 'site' => nil }
+search(
+  :node,
+  "\
+  splunk_clustering_enabled:true AND \
+  splunk_clustering_mode:master AND \
+  chef_environment:#{node.chef_environment}",
+  filter_result: {
+    'cluster_master_mgmt_uri' => %w(splunk shclustering mgmt_uri),
+    'cluster_master_site' => %w(splunk clustering site),
+    'cluster_num_sites' => %w(splunk clustering num_sites),
+  }
+).each do |result|
+  cluster_master['mgmt_uri'] = result['cluster_master_mgmt_uri']
+  cluster_master['site'] = result['cluster_master_site']
+  cluster_master['num_sites'] = result['cluster_num_sites']
+end
+
+shpeer_integration_command = "#{splunk_cmd} edit cluster-config -mode searchhead -master_uri #{cluster_master['mgmt_uri']} " \
+                             "-secret #{node.run_state['splunk_secret']} -auth #{node.run_state['splunk_auth_info']}"
+shpeer_integration_command += ' -site site0' if cluster_master['num_sites'] > 1
+
+execute 'search head cluster integration with indexer cluster' do
+  sensitive true
+  command shpeer_integration_command
+  notifies :restart, 'service[splunk]'
+  not_if { search_heads_peered? }
 end

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -5,6 +5,8 @@ describe 'chef-splunk::server' do
     ChefSpec::ServerRunner.new do |node|
       node.force_default['dev_mode'] = true
       node.force_default['splunk']['accept_license'] = true
+      node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+      node.run_state['splunk_secret'] = 'notarealsecret'
     end
   end
 

--- a/spec/recipes/setup_auth_spec.rb
+++ b/spec/recipes/setup_auth_spec.rb
@@ -7,6 +7,8 @@ describe 'chef-splunk::setup_auth' do
         node.force_default['dev_mode'] = true
         node.force_default['splunk']['is_server'] = true
         node.force_default['splunk']['accept_license'] = true
+        node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        node.run_state['splunk_secret'] = 'notarealsecret'
       end
     end
 

--- a/spec/recipes/setup_clustering_spec.rb
+++ b/spec/recipes/setup_clustering_spec.rb
@@ -14,14 +14,9 @@ shared_examples 'a successful run' do |params|
 end
 
 describe 'chef-splunk::setup_clustering' do
-  let(:vault_item) do
-    { 'auth' => 'admin:notarealpassword', 'secret' => 'notarealsecret' }
-  end
-
   before do
     allow_any_instance_of(::File).to receive(:exist?).and_call_original
     allow_any_instance_of(::File).to receive(:exist?).with('/opt/splunk/etc/.setup_clustering').and_return(false)
-    allow_any_instance_of(Chef::Recipe).to receive(:chef_vault_item).and_return(vault_item)
   end
 
   context 'default server settings' do
@@ -30,6 +25,8 @@ describe 'chef-splunk::setup_clustering' do
         node.force_default['dev_mode'] = true
         node.force_default['splunk']['is_server'] = true
         node.force_default['splunk']['accept_license'] = true
+        node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        node.run_state['splunk_secret'] = 'notarealsecret'
       end.converge(described_recipe)
     end
 
@@ -45,34 +42,47 @@ describe 'chef-splunk::setup_clustering' do
         node.force_default['splunk']['is_server'] = true
         node.force_default['splunk']['accept_license'] = true
         node.force_default['splunk']['clustering']['enabled'] = true
+        node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        node.run_state['splunk_secret'] = 'notarealsecret'
       end
     end
 
     context 'invalid cluster mode settings' do
       let(:chef_run) do
         chef_run_init.node.force_default['splunk']['clustering']['mode'] = 'foo'
-        chef_run_init.converge(described_recipe)
+        chef_run_init
       end
 
       it 'raises an error' do
-        expect { chef_run }.to raise_error(RuntimeError)
+        expect{ chef_run.converge(described_recipe) }.to raise_error(RuntimeError, 'Failed to setup clustering: invalid clustering mode')
       end
     end
 
     context 'cluster master mode' do
       let(:chef_run) do
+        chef_run_init.node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        chef_run_init.node.run_state['splunk_secret'] = 'notarealsecret'
         chef_run_init.node.force_default['splunk']['clustering']['mode'] = 'master'
-        chef_run_init.converge(described_recipe)
+        chef_run_init
       end
 
       context 'default settings (single-site)' do
+        before do
+          chef_run.converge(described_recipe)
+        end
         it_performs 'a successful run', '-mode master -replication_factor 3 -search_factor 2'
       end
 
       context 'multisite clustering with default settings' do
         let(:chef_run) do
           chef_run_init.node.force_default['splunk']['clustering']['num_sites'] = 2
-          chef_run_init.converge(described_recipe)
+          chef_run_init.node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+          chef_run_init.node.run_state['splunk_secret'] = 'notarealsecret'
+          chef_run_init
+        end
+
+        before do
+          chef_run.converge(described_recipe)
         end
 
         it_performs 'a successful run', '-mode master -multisite true -available_sites site1,site2 -site site1' \
@@ -83,7 +93,13 @@ describe 'chef-splunk::setup_clustering' do
         let(:chef_run) do
           chef_run_init.node.force_default['splunk']['clustering']['replication_factor'] = 5
           chef_run_init.node.force_default['splunk']['clustering']['search_factor'] = 3
-          chef_run_init.converge(described_recipe)
+          chef_run_init.node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+          chef_run_init.node.run_state['splunk_secret'] = 'notarealsecret'
+          chef_run_init
+        end
+
+        before do
+          chef_run.converge(described_recipe)
         end
 
         it_performs 'a successful run', '-mode master -replication_factor 5 -search_factor 3'
@@ -95,7 +111,11 @@ describe 'chef-splunk::setup_clustering' do
           chef_run_init.node.force_default['splunk']['clustering']['site'] = 'site2'
           chef_run_init.node.force_default['splunk']['clustering']['site_replication_factor'] = 'origin:2,site1:1,site2:1,total:4'
           chef_run_init.node.force_default['splunk']['clustering']['site_search_factor'] = 'origin:1,site1:1,site2:1,total:3'
-          chef_run_init.converge(described_recipe)
+          chef_run_init
+        end
+
+        before do
+          chef_run.converge(described_recipe)
         end
 
         it_performs 'a successful run', '-mode master -multisite true -available_sites site1,site2,site3 -site site2' \
@@ -104,12 +124,9 @@ describe 'chef-splunk::setup_clustering' do
     end
 
     context 'cluster search head mode' do
-      before do
-        chef_run_init.node.force_default['splunk']['clustering']['enabled'] = true
-        chef_run_init.node.force_default['splunk']['clustering']['mode'] = 'searchhead'
-
-        # Publish mock cluster master node to the server
-        cluster_master_node = stub_node(platform: 'ubuntu', version: '16.04') do |node|
+      # Publish mock cluster master node to the server
+      let(:cluster_master_node) do
+        stub_node(platform: 'ubuntu', version: '16.04') do
           node.automatic['fqdn'] = 'cm.cluster.example.com'
           node.automatic['ipaddress'] = '192.168.0.10'
           node.force_default['dev_mode'] = true
@@ -118,30 +135,45 @@ describe 'chef-splunk::setup_clustering' do
           node.force_default['splunk']['mgmt_port'] = '8089'
           node.force_default['splunk']['clustering']['enabled'] = true
           node.force_default['splunk']['clustering']['mode'] = 'master'
+          node.force_default['splunk']['clustering']['mgmt_uri'] = 'https://192.168.0.10:8089'
+          node.force_default['splunk']['shclustering']['mgmt_uri'] = 'https://192.168.0.10:8089'
         end
+      end
+
+      before do
+        chef_run_init.node.force_default['splunk']['clustering']['enabled'] = true
+        chef_run_init.node.force_default['splunk']['clustering']['mode'] = 'searchhead'
         chef_run_init.create_node(cluster_master_node)
-        chef_run_init.converge(described_recipe)
       end
 
       context 'default settings (single-site)' do
         let(:chef_run) do
-          chef_run_init.converge(described_recipe)
+          chef_run_init.node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+          chef_run_init.node.run_state['splunk_secret'] = 'notarealsecret'
+          chef_run_init
+        end
+
+        before do
+          chef_run.converge(described_recipe)
         end
 
         it_performs 'a successful run', '-mode searchhead -master_uri https://192.168.0.10:8089 -replication_port 9887'
       end
 
-      context 'multisite clustering with default settings' do
-        before(:each) do
-          chef_run_init.node.force_default['splunk']['clustering']['num_sites'] = 2
-          chef_run_init.node.force_default['splunk']['clustering']['site'] = 'site2'
-        end
-
+      context 'default settings (multi-site)' do
         let(:chef_run) do
-          chef_run_init.converge(described_recipe)
+          chef_run_init.node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+          chef_run_init.node.run_state['splunk_secret'] = 'notarealsecret'
+          chef_run_init.node.force_default['splunk']['clustering']['num_sites'] = 3
+          chef_run_init
         end
 
-        it_performs 'a successful run', '-mode searchhead -master_uri https://192.168.0.10:8089 -replication_port 9887'
+        before do
+          allow_any_instance_of(Chef::Recipe).to receive(:multisite_clustering?).and_return(true)
+          chef_run.converge(described_recipe)
+        end
+
+        it_performs 'a successful run', '-mode searchhead -site site1 -master_uri https://192.168.0.10:8089 -replication_port 9887'
       end
     end
   end

--- a/spec/recipes/setup_clustering_spec.rb
+++ b/spec/recipes/setup_clustering_spec.rb
@@ -54,7 +54,7 @@ describe 'chef-splunk::setup_clustering' do
       end
 
       it 'raises an error' do
-        expect{ chef_run.converge(described_recipe) }.to raise_error(RuntimeError, 'Failed to setup clustering: invalid clustering mode')
+        expect { chef_run.converge(described_recipe) }.to raise_error(RuntimeError, 'Failed to setup clustering: invalid clustering mode')
       end
     end
 

--- a/spec/recipes/setup_shclustering_spec.rb
+++ b/spec/recipes/setup_shclustering_spec.rb
@@ -4,10 +4,6 @@ describe 'chef-splunk::setup_shclustering' do
   let(:splunk_local_dir) { '/opt/splunk/etc/apps/0_autogen_shcluster_config/local' }
   let(:server_conf_file) { "#{splunk_local_dir}/server.conf" }
 
-  let(:vault_item) do
-    { 'auth' => 'admin:notarealpassword', 'secret' => 'notarealsecret' }
-  end
-
   let(:deployer_node) do
     stub_node(platform: 'ubuntu', version: '16.04') do |node|
       node.automatic['fqdn'] = 'deploy.cluster.example.com'
@@ -21,95 +17,65 @@ describe 'chef-splunk::setup_shclustering' do
 
   context 'search head deployer' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
+      ChefSpec::ServerRunner.new do |node, server|
+        node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        node.run_state['splunk_secret'] = 'notarealsecret'
         node.force_default['dev_mode'] = true
         node.force_default['splunk']['is_server'] = true
         node.force_default['splunk']['shclustering']['enabled'] = true
         node.force_default['splunk']['accept_license'] = true
         node.force_default['splunk']['shclustering']['mode'] = 'deployer'
+        create_data_bag_item(server, 'vault', 'splunk__default')
       end.converge(described_recipe)
     end
-
-    before do
-      allow_any_instance_of(Chef::Recipe).to receive(:chef_vault_item).and_return(vault_item)
-    end
-
-    it_behaves_like 'common server.conf settings'
   end
 
   context 'search head cluster member settings' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
+      ChefSpec::ServerRunner.new do |node, server|
+        node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        node.run_state['splunk_secret'] = 'notarealsecret'
+        node.force_default['dev_mode'] = true
+        node.force_default['splunk']['is_server'] = true
+        node.force_default['splunk']['shclustering']['enabled'] = true
+        node.force_default['splunk']['accept_license'] = true
+        node.force_default['splunk']['shclustering']['deployer_url'] = "https://#{deployer_node['fqdn']}:8089"
+        node.force_default['splunk']['shclustering']['mode'] = 'member'
+        node.force_default['splunk']['shclustering']['mgmt_uri'] = "https://#{node['fqdn']}:8089"
+        node.force_default['splunk']['shclustering']['shcluster_members'] = \
+          %w(https://shcluster-member01:8089 https://shcluster-member02:8089 https://shcluster-member03:8089)
+        create_data_bag_item(server, 'vault', 'splunk__default')
+      end.converge(described_recipe)
+    end
+
+    it_behaves_like 'a search head cluster member'
+  end
+
+  context 'search head captain' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new do |node, server|
+        node.run_state['splunk_auth_info'] = 'admin:notarealpassword'
+        node.run_state['splunk_secret'] = 'notarealsecret'
         node.force_default['dev_mode'] = true
         node.force_default['splunk']['is_server'] = true
         node.force_default['splunk']['shclustering']['enabled'] = true
         node.force_default['splunk']['accept_license'] = true
         node.force_default['splunk']['shclustering']['deployer_url'] = "https://#{deployer_node['fqdn']}:8089"
         node.force_default['splunk']['shclustering']['mgmt_uri'] = "https://#{node['fqdn']}:8089"
-        node.force_default['splunk']['shclustering']['shcluster_members'] = [
-          'https://shcluster-member01:8089',
-          'https://shcluster-member02:8089',
-          'https://shcluster-member03:8089',
-        ]
+        node.force_default['splunk']['shclustering']['mode'] = 'captain'
+        node.force_default['splunk']['shclustering']['shcluster_members'] = \
+          %w(https://shcluster-member01:8089 https://shcluster-member02:8089 https://shcluster-member03:8089)
+        create_data_bag_item(server, 'vault', 'splunk__default')
+        allow_any_instance_of(Chef::Resource).to receive(:shcaptain_elected?).and_return(false)
       end.converge(described_recipe)
     end
 
-    before do
-      allow_any_instance_of(Chef::Recipe).to receive(:chef_vault_item).and_return(vault_item)
+    let(:shcluster_servers_list) do
+      'https://shcluster-member01:8089,https://shcluster-member02:8089,https://shcluster-member03:8089'
     end
 
-    it_behaves_like 'common server.conf settings'
-
-    it 'writes a file marker to ensure convergence' do
-      expect(chef_run).to render_file('/opt/splunk/etc/.setup_shcluster').with_content("true\n")
-    end
-
-    it 'writes server.conf with replication port' do
-      expect(chef_run).to render_file(server_conf_file)
-        .with_content("[replication_port://#{chef_run.node['splunk']['shclustering']['replication_port']}]")
-    end
-
-    it 'writes server.conf with the deployer url' do
-      expect(chef_run).to render_file(server_conf_file)
-        .with_content("conf_deploy_fetch_url = #{chef_run.node['splunk']['shclustering']['deployer_url']}")
-    end
-
-    it 'writes server.conf with the node mgmt uri' do
-      expect(chef_run).to render_file(server_conf_file)
-        .with_content("mgmt_uri = #{chef_run.node['splunk']['shclustering']['mgmt_uri']}")
-    end
-
-    it 'writes server.conf with the shcluster replication factor' do
-      expect(chef_run).to render_file(server_conf_file)
-        .with_content("replication_factor = #{chef_run.node['splunk']['shclustering']['replication_factor']}")
-    end
-
-    it 'does not run command to bootstrap captain' do
-      expect(chef_run).to_not run_execute('bootstrap-shcluster')
-    end
-
-    context 'while set to captain mode' do
-      context 'during initial chef run' do
-        before(:each) do
-          chef_run.node.force_default['splunk']['shclustering']['mode'] = 'captain'
-          allow_any_instance_of(::File).to receive(:exist?).and_call_original
-          allow_any_instance_of(::File).to receive(:exist?)
-            .with('/opt/splunk/etc/.setup_shcluster').and_return(false)
-          chef_run.converge(described_recipe)
-        end
-
-        let(:shcluster_servers_list) do
-          chef_run.node.force_default['splunk']['shclustering']['shcluster_members'].join(',')
-        end
-
-        it 'runs command to bootstrap captain with correct parameters' do
-          expect(chef_run).to run_execute('bootstrap-shcluster').with(
-            command: "/opt/splunk/bin/splunk bootstrap shcluster-captain -servers_list '#{shcluster_servers_list}'" \
-                     " -auth 'admin:notarealpassword'"
-          )
-          expect(chef_run.execute('bootstrap-shcluster')).to notify('service[splunk]').to(:restart)
-        end
-      end
+    it 'executes bootstrap sh-captain command' do
+      expect(chef_run).to run_execute('bootstrap-shcluster-captain')
     end
   end
 end

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -15,5 +15,8 @@ shared_context 'command stubs' do
     stubs_for_resource('execute[bootstrap-shcluster-captain]') do |resource|
       allow(resource).to receive_shell_out('/opt/splunk/bin/splunk list shcluster-members -auth admin:notarealpassword | grep is_captain:1')
     end
+    stubs_for_resource("execute[update-splunk-mgmt-port]") do |resource|
+      allow(resource).to receive_shell_out("/opt/splunk/bin/splunk show splunkd-port -auth admin:notarealpassword | awk -F: '{print$NF}'")
+    end
   end
 end

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -15,7 +15,7 @@ shared_context 'command stubs' do
     stubs_for_resource('execute[bootstrap-shcluster-captain]') do |resource|
       allow(resource).to receive_shell_out('/opt/splunk/bin/splunk list shcluster-members -auth admin:notarealpassword | grep is_captain:1')
     end
-    stubs_for_resource("execute[update-splunk-mgmt-port]") do |resource|
+    stubs_for_resource('execute[update-splunk-mgmt-port]') do |resource|
       allow(resource).to receive_shell_out("/opt/splunk/bin/splunk show splunkd-port -auth admin:notarealpassword | awk -F: '{print$NF}'")
     end
   end

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -1,0 +1,19 @@
+shared_context 'command stubs' do
+  before(:each) do
+    stubs_for_resource('execute[initialize search head cluster member]') do |resource|
+      allow(resource).to receive_shell_out('/opt/splunk/bin/splunk list shcluster-member-info -auth admin:notarealpassword')
+    end
+    stubs_for_resource('execute[add member to search head cluster]') do |resource|
+      allow(resource).to receive_shell_out('/opt/splunk/bin/splunk list shcluster-member-info -auth admin:notarealpassword')
+    end
+    stubs_for_resource('execute[search head cluster integration with indexer cluster]') do |resource|
+      allow(resource).to receive_shell_out('/opt/splunk/bin/splunk list search-server -auth admin:notarealpassword')
+    end
+    stubs_for_resource('service[splunk]') do |resource|
+      allow(resource).to receive_shell_out("ps -ef|grep splunk|grep -v grep|awk '{print$1}'|uniq")
+    end
+    stubs_for_resource('execute[bootstrap-shcluster-captain]') do |resource|
+      allow(resource).to receive_shell_out('/opt/splunk/bin/splunk list shcluster-members -auth admin:notarealpassword | grep is_captain:1')
+    end
+  end
+end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,20 +1,10 @@
-shared_examples 'common server.conf settings' do
-  let(:splunk_local_dir) { '/opt/splunk/etc/apps/0_autogen_shcluster_config/local' }
-  let(:server_conf_file) { "#{splunk_local_dir}/server.conf" }
-
-  it 'writes server.conf with a shclustering stanza' do
-    expect(chef_run).to render_file(server_conf_file)
-      .with_content('[shclustering]')
+shared_examples 'a search head cluster member' do
+  it 'executes initialize shcluster member command' do
+    expect(chef_run).to_not run_execute('initialize search head cluster member')
   end
 
-  it 'writes server.conf with the shcluster label' do
-    expect(chef_run).to render_file(server_conf_file)
-      .with_content("shcluster_label = #{chef_run.node['splunk']['shclustering']['label']}")
-  end
-
-  it 'writes server.conf with the shcluster secret' do
-    expect(chef_run).to render_file(server_conf_file)
-      .with_content('pass4SymmKey = notarealsecret')
+  it 'creates /opt/splunk/etc/.setup_shcluster' do
+    expect(chef_run).to_not create_file('/opt/splunk/etc/.setup_shcluster')
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,15 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'shared_examples'
+require_relative 'shared_contexts'
+
+FIXTURES_DIR = ::File.join('test', 'fixtures')
+DATA_BAG_DIR = ::File.join(FIXTURES_DIR, 'data_bags')
+
+def create_data_bag_item(server, bag, item)
+  db_path = ::File.join(DATA_BAG_DIR, bag, "#{item}.json")
+  server.create_data_bag(bag, item => JSON.parse(::File.read(db_path)))
+end
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
@@ -9,6 +18,7 @@ RSpec.configure do |config|
 
   config.platform = 'ubuntu'        # Avoid warnings in ChefSpec
   config.version = '16.04'          # Avoid warnings in ChefSpec
-
+  config.example_status_persistence_file_path = 'spec/examples.txt'
   config.alias_it_should_behave_like_to :it_performs, 'performs'
+  config.include_context 'command stubs'
 end


### PR DESCRIPTION
### Description

- Adds attribute `node['splunk']['shclustering']['app_dir']` to take the place of local ruby
  variable to set the search head clustering application directory.
- Uses the splunk CLI to add search head cluster members instead of the app server.conf file
  to ensure members are properly added. SH cluster members wait for the captain to converge.
- Search Head Captains will initialize as a search head cluster member and then bootstrap themselves
- Improves idempotent addition of search head cluster members
- Fixes issue [#137](https://github.com/chef-cookbooks/chef-splunk/issues/137)
    - Adds logic to skip any initialization or bootstrapping of search head cluster resources.
- Fixes issue [#138](https://github.com/chef-cookbooks/chef-splunk/issues/138)
    - Adds a new property to the `splunk_app` resource, called `template_variables`
- Fixes issue [#139](https://github.com/chef-cookbooks/chef-splunk/issues/139)
    - Adds `cookbook` property to the template declared in the `splunk_app` provider
- Fixes issue [#140](https://github.com/chef-cookbooks/chef-splunk/issues/140)
    - Adds back resource actions: :enable, :disable, :install, :remove
- Fixes issue [#141](https://github.com/chef-cookbooks/chef-splunk/issues/141)
    - `app_dir` property was added to the `splunk_app` resource
- Integrates a search head cluster to a single or multisite indexer cluster
- Adds helper method `#add_shcluster_member?` to indicate whether a search head cluster member needs to
  be added to the search head cluster
- Adds support for Hash when providing the `templates` property to the `splunk_app` resource
- Adds `:update` action to `splunk_app` resource


### Issues Resolved

#137 
#139 
#140 
#141 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
