### PR TITLE
Fixed Issue #111, other feature fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
-## 4.1.0 (TBD)
+## 5.0.0 (TBD)
+- `splunk_app` no longer uses the `splunk install app` and `splunk disable app` commands; preference
+  to managing the files in <splunk_dir>/etc/apps, or the alternative directories, directly, and restarting/reloading
+  Splunk, as needed.
+- Removes these actions from `splunk_app`: `:disable`, `:enable`, and `:update`
+- `splunk_app` now has two actions only: `:install` (default) and `:remove`
+  - `:install` action will also update app config files, as needed
+- Fixes Issue [#111](https://github.com/chef-cookbooks/chef-splunk/issues/111)
+  * with so many ways to "unpack" a compressed bundle file (e.g., tar.gz, zip, bz2), this feature
+    will not attempt to support any/all of the possibilities. In contrast, this feature will support
+    installing an app from any local source on the chef node and into the /opt/splunk/etc/apps directory, unless
+    otherwise specified by the `app_dir` property.
+
+## 4.1.0 (2020-02-06)
 - Adds attribute `node['splunk']['shclustering']['app_dir']` to take the place of local ruby
   variable to set the search head clustering application directory.
 - Uses the splunk CLI to add search head cluster members instead of the app server.conf file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This file is used to list changes made in each version of the splunk cookbook.
     will not attempt to support any/all of the possibilities. In contrast, this feature will support
     installing an app from any local source on the chef node and into the /opt/splunk/etc/apps directory, unless
     otherwise specified by the `app_dir` property.
+- The `sensitive` property is honored by the `splunk_app` resource.
 
 ## 4.1.0 (2020-02-06)
 - Adds attribute `node['splunk']['shclustering']['app_dir']` to take the place of local ruby

--- a/README.md
+++ b/README.md
@@ -345,17 +345,16 @@ default Splunk settings. The latter is desirable for maintaining settings after 
 Splunk Enterprise server software.
 
 #### Actions
-* `:enable`: Enables a Splunk app after it has been disabled or newly installed
-* `:disable`: Disables a Splunk app and leaves it installed
-* `:install`: Installs a Splunk app or deployment app
-* `:update`: Updates a Splunk app that was previously installed. If the app is not installed, this action will
-  go ahead and install the app as if `:install` was specified.
+* `:install`: Installs a Splunk app or deployment app. This action will also update existing app config files, as needed
 * `:remove`: Completely removes a Splunk app or deployment app from the Splunk Enterprise server
 
 #### Properties
-# TODO: document the rest of the splunk_app properties
+### TODO: document the rest of the splunk_app properties
 
-* `cookbook`: Used in conjunction with the `templates` property, this specifies the cookbook where templates will be sourced
+* `app_dir`: Specifies the application's installation path. Apps installed with this property will be done relative
+  to the Splunk installation directory (Default: /opt/splunk).
+* `local_file`: specifies a local path where an app will be sourced. This will not download an app from a remote
+  source, as it assumes the file or bundle has been done so outside of this resource. With so many ways to "unpack" a compressed bundle file (e.g., tar.gz, zip, bz2), this feature will not attempt to support any/all of the possibilities. In contrast, this feature will support installing an app from any local source on the chef node and into the /opt/splunk/etc/apps directory, unless otherwise specified by the `app_dir` property.
 
 * `templates`: This is either an array of template names or a Hash consisting of a target destination path and template names
   For example: `['server.conf.erb']` or `{ 'etc/deployment-apps' => 'server.conf.erb' }`.

--- a/libraries/splunk_app_resource.rb
+++ b/libraries/splunk_app_resource.rb
@@ -24,15 +24,15 @@ class Chef
       self.resource_name = 'splunk_app'
 
       # Actions correspond to splunk commands pertaining to apps.
-      actions :enable, :disable, :install, :update, :remove
-      default_action :enable
-      state_attrs :enabled, :installed
+      actions :install, :remove
+      default_action :install
+      state_attrs :installed
 
       attribute :app_name, kind_of: String, name_attribute: true
       attribute :app_dir, kind_of: String, default: nil
       attribute :remote_file, kind_of: String, default: nil
       attribute :cookbook_file, kind_of: String, default: nil
-      attribute :cookbook, kind_of: String, default: nil
+      attribute :local_file, kind_of: String, default: nil
       attribute :checksum, kind_of: String, default: nil
       attribute :remote_directory, kind_of: String, default: nil
       attribute :splunk_auth, kind_of: [String, Array], required: true
@@ -43,7 +43,6 @@ class Chef
       # each template named in the templates property, above, with each template having its
       # unique set of variables and values
       attribute :template_variables, kind_of: Hash, default: { 'default' => {} }
-      attribute :enabled, kind_of: [TrueClass, FalseClass, NilClass], default: false
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,14 +3,16 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '4.1.0'
+version '5.0.0'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'
 supports 'redhat', '>= 6.9'
 supports 'centos', '>= 6.9'
 supports 'amazon'
+
 depends 'chef-vault', '~> 4.0'
+
 source_url 'https://github.com/chef-cookbooks/chef-splunk'
 issues_url 'https://github.com/chef-cookbooks/chef-splunk/issues'
 chef_version '>= 13.11'


### PR DESCRIPTION
- `splunk_app` no longer uses the `splunk install app` and `splunk disable app` commands; preference
  to managing the files in <splunk_dir>/etc/apps, or the alternative directories, directly, and restarting/reloading
  Splunk, as needed.
- Removes these actions from `splunk_app`: `:disable`, `:enable`, and `:update`
- `splunk_app` now has two actions only: `:install` (default) and `:remove`
  - `:install` action will also update app config files, as needed
- Fixes Issue [#111](https://github.com/chef-cookbooks/chef-splunk/issues/111)
  * with so many ways to "unpack" a compressed bundle file (e.g., tar.gz, zip, bz2), this feature
    will not attempt to support any/all of the possibilities. In contrast, this feature will support
    installing an app from any local source on the chef node and into the /opt/splunk/etc/apps directory, unless
    otherwise specified by the `app_dir` property.
