### PR TITLE
removes unnecessary calls to `#run_command` method when `#shell_out` …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 5.0.2 (2020-02-20)
+- removes unnecessary `#run_command` calls when `shell_out` is used
+
 ## 5.0.1 (2020-02-10)
 - Fixes Issue [#146](https://github.com/chef-cookbooks/chef-splunk/issues/146)
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -115,7 +115,6 @@ end
 
 def current_mgmt_port
   splunk = shell_out("#{splunk_cmd} show splunkd-port -auth #{node.run_state['splunk_auth_info']} | awk -F: '{print$NF}'")
-  splunk.run_command
   splunk.error! # Raise an exception if it didn't exit with 0
   splunk.stdout.strip
 end
@@ -144,7 +143,6 @@ end
 # returns true if the splunkd process is owned by the correct "run-as" user
 def correct_runas_user?
   splunk = shell_out("ps -ef|grep splunk|grep -v grep|awk '{print$1}'|uniq")
-  splunk.run_command
   splunk_runas_user == splunk.stdout
 end
 
@@ -158,7 +156,6 @@ end
 
 def init_shcluster_member?
   list_member_info = shell_out("#{splunk_cmd} list shcluster-member-info -auth #{node.run_state['splunk_auth_info']}")
-  list_member_info.run_command
   list_member_info.error?
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '5.0.1'
+version '5.0.2'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'


### PR DESCRIPTION
…is used in the helper methods

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

### Description

overzealous calls in the helper methods to `#run_command` are removed by this PR.


### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
