### PR TITLE
`splunk_app` resources adds new property: `template_sources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 5.0.3 (2020-02-24)
+- `splunk_app` resource adds new property: `template_sources`
+
 ## 5.0.2 (2020-02-20)
 - removes unnecessary `#run_command` calls when `shell_out` is used
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,18 @@ Splunk Enterprise server software.
   end
   ```
 
+* `template_sources`: This is a Hash to specify the source file to use for each template.
+
+For example, this will use a server.conf.erb template file located in templates/custom/server.conf.erb of this cookbook:
+```ruby
+splunk_app 'my app' do
+  templates %w(server.conf.erb)
+  template_sources {
+    'server.conf.erb' => 'custom'
+  }
+end
+```
+
 
 #### Examples
 

--- a/libraries/splunk_app_provider.rb
+++ b/libraries/splunk_app_provider.rb
@@ -154,9 +154,10 @@ class Chef
                                    new_resource.template_variables['default']
                                  end
             t = t.match?(/(\.erb)*/) ? ::File.basename(t, '.erb') : t
+            template_source_dir = new_resource.template_sources.empty? ? new_resource.app_name : new_resource.template_sources[t]
 
             template "#{dir}/local/#{t}" do
-              source "#{new_resource.app_name}/#{t}.erb"
+              source "#{template_source_dir}/#{t}.erb"
               variables template_variables
               sensitive new_resource.sensitive
               owner splunk_runas_user

--- a/libraries/splunk_app_resource.rb
+++ b/libraries/splunk_app_resource.rb
@@ -39,10 +39,11 @@ class Chef
       attribute :app_dependencies, kind_of: Array, default: []
       attribute :templates, kind_of: [Array, Hash], default: []
 
-      # template_variables is a Hash referencing
+      # template_variables and template_sources are Hashes referencing
       # each template named in the templates property, above, with each template having its
-      # unique set of variables and values
+      # unique set of variables and values and the source, respectively.
       attribute :template_variables, kind_of: Hash, default: { 'default' => {} }
+      attribute :template_sources, kind_of: Hash, default: {}
       attribute :installed, kind_of: [TrueClass, FalseClass, NilClass], default: false
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '5.0.2'
+version '5.0.3'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'


### PR DESCRIPTION
Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

### Description

it's sometimes necessary to share a template between different apps that are deployed by `splunk_app`. This change will allow a Hash of sources to be specifies.

The `splunk_app` resource adds new property: `template_sources`

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
