### PR TITLE
Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 5.0.3 (TBD)
+- fixes minimum number of search head cluster members required to bootstrap the captain
+- fixes search head cluster captain discovery
+- fixes the logic that determines when a search head cluster captain can be bootstrapped
+- fixes the logic that determines when a search head cluster member can be added to its cluster
+- adds helper methods:
+  * `#shcluster_member?`
+  * `#shcaptain_elected?`
+  * `#ok_to_bootstrap_captain?`
+  * `#ok_to_add_member?`
+  * `#shcluster_servers_list`
+
 ## 5.0.2 (2020-02-20)
 - removes unnecessary `#run_command` calls when `shell_out` is used
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This file is used to list changes made in each version of the splunk cookbook.
   * `#ok_to_bootstrap_captain?`
   * `#ok_to_add_member?`
   * `#shcluster_servers_list`
+  * `#hash_password`
+- To prevent overzealous restarts of splunkd, detects when the pass4symmkey has already been encrypted by splunkd
 
 ## 5.0.2 (2020-02-20)
 - removes unnecessary `#run_command` calls when `shell_out` is used

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,7 @@ default['splunk']['ssl_options'] = {
 
 default['splunk']['clustering'] = {
   'enabled' => false,
+  'label' => 'cluster1',
   'num_sites' => 1,   # multisite is true if num_sites > 1
   'mgmt_uri' => "https://#{node['fqdn']}:8089",
   'mode' => 'master', # master|slave|searchhead
@@ -60,6 +61,7 @@ default['splunk']['clustering'] = {
 
 default['splunk']['shclustering'] = {
   'app_dir' => '/opt/splunk/etc/apps/0_autogen_shcluster_config',
+  'captain_elected' => false,
   'deployer_url' => '',
   'enabled' => false,
   'label' => 'shcluster1',

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -84,6 +84,7 @@ end
 # returns the output of splunk's HASHED_PASSWORD command
 # this command produces a hash of a clear-text password that can be stored in user-seed.conf, for example
 def hash_passwd(pw)
+  return pw if pw.match?(/^\$\d*\$/)
   hash = shell_out("#{splunk_cmd} hash-passwd #{pw}")
   hash.stdout.strip
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -81,6 +81,13 @@ def splunk_auth(auth)
   end
 end
 
+# returns the output of splunk's HASHED_PASSWORD command
+# this command produces a hash of a clear-text password that can be stored in user-seed.conf, for example
+def hash_passwd(pw)
+  hash = shell_out("#{splunk_cmd} hash-passwd #{pw}")
+  hash.stdout.strip
+end
+
 def splunk_runas_user
   return 'root' if node['splunk']['server']['runasroot'] == true
   node['splunk']['user']['username']

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '5.0.2'
+version '5.0.3'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 if disabled?
   include_recipe 'chef-splunk::disabled'
   Chef::Log.debug('Splunk is disabled on this node.')

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -52,7 +52,7 @@ template 'user-seed.conf' do
   owner splunk_runas_user
   group splunk_runas_user
   mode '600'
-  sensitive false
+  sensitive true
   variables user: user, hashed_password: lazy { hash_passwd(pw) }
   notifies :delete, "file[#{splunk_dir}/etc/passwd]", :immediately
   notifies :restart, 'service[splunk]', :immediately

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -26,6 +26,7 @@ unless setup_auth?
 end
 
 include_recipe 'chef-splunk'
+
 user, pw = node.run_state['splunk_auth_info'].split(':')
 
 # during an initial install, the start/restart commands must deal with accepting
@@ -41,14 +42,19 @@ edit_resource(:service, 'splunk') do
   provider splunk_service_provider
 end
 
+file "#{splunk_dir}/etc/passwd" do
+  action :nothing
+end
+
 template 'user-seed.conf' do
   path "#{splunk_dir}/etc/system/local/user-seed.conf"
   source 'user-seed-conf.erb'
   owner splunk_runas_user
   group splunk_runas_user
   mode '600'
-  sensitive true
-  variables user: user, password: pw
+  sensitive false
+  variables user: user, hashed_password: lazy { hash_passwd(pw) }
+  notifies :delete, "file[#{splunk_dir}/etc/passwd]", :immediately
   notifies :restart, 'service[splunk]', :immediately
   not_if { ::File.exist?("#{splunk_dir}/etc/system/local/.user-seed.conf") }
 end

--- a/templates/user-seed-conf.erb
+++ b/templates/user-seed-conf.erb
@@ -1,3 +1,3 @@
 [user_info]
 USERNAME = <%= @user %>
-PASSWORD = <%= @password %>
+HASHED_PASSWORD = <%= @hashed_password %>


### PR DESCRIPTION
### Description

- fixes minimum number of search head cluster members required to bootstrap the captain
- fixes search head cluster captain discovery
- fixes the logic that determines when a search head cluster captain can be bootstrapped
- fixes the logic that determines when a search head cluster member can be added to its cluster
- adds helper methods:
  * `#shcluster_member?`
  * `#shcaptain_elected?`
  * `#ok_to_bootstrap_captain?`
  * `#ok_to_add_member?`

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
