### PR TITLE
Fixes Issue #152 - removes `splunk_auth` property from `splunk_app` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 5.0.4 (2020-03-07)
+- Fixes Issue [#152](https://github.com/chef-cookbooks/chef-splunk/issues/152)
+  * Removes `splunk_auth` property from the `splunk_app` resources (no longer required)
+
 ## 5.0.3 (2020-03-06)
 - fixes minimum number of search head cluster members required to bootstrap the captain
 - fixes search head cluster captain discovery

--- a/libraries/splunk_app_resource.rb
+++ b/libraries/splunk_app_resource.rb
@@ -35,7 +35,6 @@ class Chef
       attribute :local_file, kind_of: String, default: nil
       attribute :checksum, kind_of: String, default: nil
       attribute :remote_directory, kind_of: String, default: nil
-      attribute :splunk_auth, kind_of: [String, Array], required: true
       attribute :app_dependencies, kind_of: Array, default: []
       attribute :templates, kind_of: [Array, Hash], default: []
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '5.0.3'
+version '5.0.4'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'


### PR DESCRIPTION
### Description

removes `splunk_auth` property from `splunk_app` resource

### Issues Resolved

#152 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
