### PR TITLE
Update splunk_app.rb to fix gh-158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.1.5 (2020-03-30)
+- Fixes issues [#158] (https://github.com/chef-cookbooks/chef-splunk/issues/158)
+  * Removes default_description as a property field
+
 ## 6.1.4 (2020-03-26)
 - Implements a `cookbook` property for the `splunk_app` custom resource
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.1.4'
+version '6.1.5'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/resources/splunk_app.rb
+++ b/resources/splunk_app.rb
@@ -31,7 +31,6 @@ property :remote_directory, kind_of: String, default: nil
 property :templates, kind_of: [Array, Hash], default: []
 property :files_mode, [String, Integer, nil],
           description: "The octal mode for a file.\n UNIX- and Linux-based systems: A quoted 3-5 character string that defines the octal mode that is passed to chmod. For example: '755', '0755', or 00755. If the value is specified as a quoted string, it works exactly as if the chmod command was passed. If the value is specified as an integer, prepend a zero (0) to the value to ensure that it is interpreted as an octal number. For example, to assign read, write, and execute rights for all users, use '0777' or '777'; for the same rights, plus the sticky bit, use 01777 or '1777'.\n Microsoft Windows: A quoted 3-5 character string that defines the octal mode that is translated into rights for Microsoft Windows security. For example: '755', '0755', or 00755. Values up to '0777' are allowed (no sticky bits) and mean the same in Microsoft Windows as they do in UNIX, where 4 equals GENERIC_READ, 2 equals GENERIC_WRITE, and 1 equals GENERIC_EXECUTE. This property cannot be used to set :full_control. This property has no effect if not specified, but when it and rights are both specified, the effects are cumulative.",
-          default_description: '0644 on *nix systems',
           regex: /^\d{3,4}$/, default: nil
 # template_variables is a Hash referencing
 # each template named in the templates property, above, with each template having its


### PR DESCRIPTION
Signed-off-by: Diego Malicia dmalicia@fuze.com


### Description

- Fixes issues [#158] (https://github.com/chef-cookbooks/chef-splunk/issues/158)
  * Removes default_description as a property field

### Issues Resolved

Fixes gh-158

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
