### PR TITLE
adds helper method `#enable_boot_start_cmd` to calculate the correct …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.1.6 (2020-04-02)
+- adds helper method `#enable_boot_start_cmd` to calculate the correct command to run `splunk enable boot-start` on systems running systemd
+
 ## 6.1.5 (2020-03-30)
 - Fixes issues [#158] (https://github.com/chef-cookbooks/chef-splunk/issues/158)
   * Removes default_description as a property field

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -236,3 +236,9 @@ def search_heads_peered?
   list_search_server = shell_out("#{splunk_cmd} list search-server -auth #{node.run_state['splunk_auth_info']}")
   list_search_server.stdout.match?(/(^Server at URI \".*\" with status as \"Up\")+/)
 end
+
+def enable_boot_start_cmd
+  "#{splunk_cmd} enable boot-start" \
+  "#{node['init_package'] == 'systemd' ? ' -systemd-managed 1' : ''}" \
+  " --answer-yes --no-prompt#{license_accepted? ? ' --accept-license' : ''}"
+end

--- a/recipes/install_forwarder.rb
+++ b/recipes/install_forwarder.rb
@@ -29,6 +29,6 @@ end
 # init script (or other configuration change) appropriate for your OS.
 execute 'enable boot-start' do
   user 'root'
-  command "#{splunk_cmd} enable boot-start --answer-yes --no-prompt#{license_accepted? ? ' --accept-license' : ''}"
+  command enable_boot_start_cmd
   creates '/etc/init.d/splunk'
 end

--- a/recipes/install_server.rb
+++ b/recipes/install_server.rb
@@ -29,6 +29,6 @@ end
 # init script (or other configuration change) appropriate for your OS.
 execute 'enable boot-start' do
   user 'root'
-  command "#{splunk_cmd} enable boot-start --answer-yes --no-prompt#{license_accepted? ? ' --accept-license' : ''}"
+  command enable_boot_start_cmd
   creates '/etc/init.d/splunk'
 end


### PR DESCRIPTION
…command to run `splunk enable boot-start` on systems running systemd

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

### Description

On systemd, the `enable boot-start` command needs the option `-systemd-managed 1`. This adds a helper method to calculate the enable boot start command.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
