### PR TITLE
ensures that transient files are skipped when fixing files/directorie…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Gemfile.lock
 *.gem
 coverage
 spec/reports
+spec/examples.txt
 
 # YARD / rdoc artifacts
 .yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.1.6 (2020-04-28)
+- ensures that transient files are skipped when fixing files/directories are owned by the splunk user
+
 ## 6.1.5 (2020-03-30)
 - Fixes issues [#158] (https://github.com/chef-cookbooks/chef-splunk/issues/158)
   * Removes default_description as a property field

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -238,7 +238,7 @@ def search_heads_peered?
 end
 
 def all_splunk_files_dirs
-  Find.find("#{splunk_dir}").reject do |x|
+  Find.find(splunk_dir.to_s).reject do |x|
     x.match(%r{/var/lib/splunk/kvstore}) # kvstore files are transient, so exclude them
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -238,7 +238,7 @@ def search_heads_peered?
 end
 
 def set_ownership
-  Dir.glob("#{splunk_dir}/**/*").select{ |e| File.file?(e) || File.directory?(e) }.each do |f|
+  Dir.glob("#{splunk_dir}/**/*").select { |e| File.file?(e) || File.directory?(e) }.each do |f|
     if File.directory?(f)
       directory f do
         owner splunk_runas_user
@@ -249,7 +249,7 @@ def set_ownership
       file f do
         owner splunk_runas_user
         group splunk_runas_user
-        only_if { File.exist?(f) } # looks redundant of the `#select`, but guards against transient splunk files causing a failed chef run
+        only_if { ::File.exist?(f) } # looks redundant of the `#select`, but guards against transient splunk files causing a failed chef run
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -249,14 +249,14 @@ def set_ownership
       directory f do
         owner splunk_runas_user
         group splunk_runas_user
-        subscribes :run, 'service[splunk]', :before
+        subscribes :create, 'service[splunk]', :before
         only_if { File.directory?(f) }
       end
     else
       file f do
         owner splunk_runas_user
         group splunk_runas_user
-        subscribes :run, 'service[splunk]', :before
+        subscribes :create, 'service[splunk]', :before
         only_if { ::File.exist?(f) }
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -236,3 +236,21 @@ def search_heads_peered?
   list_search_server = shell_out("#{splunk_cmd} list search-server -auth #{node.run_state['splunk_auth_info']}")
   list_search_server.stdout.match?(/(^Server at URI \".*\" with status as \"Up\")+/)
 end
+
+def set_ownership
+  Dir.glob("#{splunk_dir}/**/*").select{ |e| File.file?(e) || File.directory?(e) }.each do |f|
+    if File.directory?(f)
+      directory f do
+        owner splunk_runas_user
+        group splunk_runas_user
+        only_if { File.directory?(f) } # looks redundant of the `#select`, but guards against transient splunk files causing a failed chef run
+      end
+    else
+      file f do
+        owner splunk_runas_user
+        group splunk_runas_user
+        only_if { File.exist?(f) } # looks redundant of the `#select`, but guards against transient splunk files causing a failed chef run
+      end
+    end
+  end
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -249,12 +249,14 @@ def set_ownership
       directory f do
         owner splunk_runas_user
         group splunk_runas_user
+        subscribes :run, 'service[splunk]', :before
         only_if { File.directory?(f) }
       end
     else
       file f do
         owner splunk_runas_user
         group splunk_runas_user
+        subscribes :run, 'service[splunk]', :before
         only_if { ::File.exist?(f) }
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.1.5'
+version '6.1.6'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -47,15 +47,8 @@ if server?
   end
 end
 
-# If we run as splunk user do a recursive chown to that user for all splunk
-# files if a few specific files are root owned.
-ruby_block 'splunk_fix_file_ownership' do
-  block do
-    FileUtils.chown_R(splunk_runas_user, splunk_runas_user, splunk_dir)
-  end
-  subscribes :run, 'service[splunk]', :before
-  not_if { node['splunk']['server']['runasroot'] == true }
-end
+# If we run as a splunk user, ensure proper file and directory ownership
+set_ownership unless node['splunk']['server']['runasroot'] == true
 
 Chef::Log.info("Node init package: #{node['init_package']}")
 


### PR DESCRIPTION
…s are owned by the splunk user

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
The resource `ruby_block[splunk_fix_file_ownership]` can cause a chef run failure due to Splunk transient files. These files, such as kvstore or hot cache files, are created and deleted by Splunk during the normal course of running Splunk. The `#chown_R` that this ruby_block executes does so on a file list that is created during the compile phase of the chef run; however, during the converge phase, those files may not exist anymore.

```
>>>> Caused by Errno::ENOENT: No such file or directory @ apply2files - /opt/splunk/var/lib/splunk/kvstore/mongo/diagnostic.data/metrics.interim.temp
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1329:in `chown'
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1329:in `chown'
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1073:in `block (2 levels) in chown_R'
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1464:in `preorder_traverse'
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1071:in `block in chown_R'
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1070:in `each'
/opt/chef/embedded/lib/ruby/2.6.0/fileutils.rb:1070:in `chown_R'
/var/chef/cache/cookbooks/chef-splunk/recipes/service.rb:54:in `block (2 levels) in from_file'
```

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>