### PR TITLE
Rescues `Errno::ENOENT` in `ruby_block['splunk_fix_file_ownership']`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Gemfile.lock
 *.gem
 coverage
 spec/reports
+spec/examples.txt
 
 # YARD / rdoc artifacts
 .yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.1.6 (2020-04-28)
+- Rescues `Errno::ENOENT` in `ruby_block['splunk_fix_file_ownership']`
+
 ## 6.1.5 (2020-03-30)
 - Fixes issues [#158] (https://github.com/chef-cookbooks/chef-splunk/issues/158)
   * Removes default_description as a property field

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.1.5'
+version '6.1.6'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -51,7 +51,11 @@ end
 # files if a few specific files are root owned.
 ruby_block 'splunk_fix_file_ownership' do
   block do
-    FileUtils.chown_R(splunk_runas_user, splunk_runas_user, splunk_dir)
+    begin
+      FileUtils.chown_R(splunk_runas_user, splunk_runas_user, splunk_dir)
+    rescue Errno::ENOENT => e
+      Chef::Log.warn "Possible transient file encountered in Splunk while setting ownership:\n#{e.message}"
+    end
   end
   subscribes :run, 'service[splunk]', :before
   not_if { node['splunk']['server']['runasroot'] == true }


### PR DESCRIPTION
Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
`Errno::ENOENT` exceptions in the `ruby_block['splunk_fix_file_ownership']` resource can cause the chef run to fail. These have shown to be thrown for transient files created by Splunk itself. This change will rescue those exceptions.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>