### PR TITLE
Fixes `#init_shcluster_member?` exception when splunk is not installe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lib/bundler/man
 pkg
 test/tmp
 test/version_tmp
+spec/examples.txt
 tmp
 _Store
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.1.7 (2020-05-13)
+- Fixes `#init_shcluster_member?` exception when splunk is not installed; will return false when splunk hasn't been installed
+
 ## 6.1.6 (2020-04-28)
 - Rescues `Errno::ENOENT` in `ruby_block['splunk_fix_file_ownership']`
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -165,6 +165,7 @@ def cluster_master?
 end
 
 def init_shcluster_member?
+  return false unless splunk_installed?
   list_member_info = shell_out("#{splunk_cmd} list shcluster-member-info -auth #{node.run_state['splunk_auth_info']}")
   list_member_info.error?
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.1.6'
+version '6.1.7'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'


### PR DESCRIPTION
…d; will return false when splunk hasn't been installed

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>