### PR TITLE
Fixes splunkd restart issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.2.5 (2020-06-16)
+- Fixes splunkd restart issue
+
 ## 6.2.4 (2020-06-15)
 - Multiple bugfixes to resolve build issues
 - Better chefspec coverage

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.2.4'
+version '6.2.5'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -112,16 +112,9 @@ template '/etc/init.d/splunk' do
   notifies :restart, 'service[splunk]'
 end
 
-# during an initial install, the start/restart commands must deal with accepting
-# the license. So, we must ensure the service[splunk] resource
-# properly deals with the license by way of the `svc_command` helper.
 service 'splunk' do
   action node['init_package'] == 'systemd' ? %i(start enable) : :start
   supports status: true, restart: true
-  stop_command svc_command('stop')
-  start_command svc_command('start')
-  restart_command svc_command('restart')
-  status_command svc_command('status')
   notifies :run, "execute[#{splunk_cmd} stop]", :before unless correct_runas_user?
   provider splunk_service_provider
 end


### PR DESCRIPTION
Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

CI tests fail due to conflicts with listening ports when restarting Splunk; this change will attempt to fix that.



### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>