### PR TITLE
Fixes Issue #168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.2.7 (2020-06-29)
+- Fixes Issue [#168](https://github.com/chef-cookbooks/chef-splunk/issues/168)
+  * uses `node.normal` when `ruby_block[captain elected]` executes to persist that value between chef runs
+  * requires manually updating node data to set `node.normal['splunk']['shclustering']['captain_elected'] = true` if you've already deployed v6.2.6 of this cookbook previously; otherwise, skip v6.2.6 and run v6.2.7 directly.
+
 ## 6.2.6 (2020-06-16)
 - changes `#shcaptain_elected?` to rely on the splunk CLI output from `show shcluster-status` to determine if a captain has been elected
 - adds new helper method: `#shcluster_captain` that returns `nil` or the name of the captain

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.2.6'
+version '6.2.7'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/setup_shclustering.rb
+++ b/recipes/setup_shclustering.rb
@@ -110,7 +110,7 @@ end
 
 ruby_block 'captain elected' do
   block do
-    node.override['splunk']['shclustering']['captain_elected'] = true
+    node.normal['splunk']['shclustering']['captain_elected'] = true
   end
   action :nothing
   subscribes :run, 'execute[bootstrap-shcluster-captain]'


### PR DESCRIPTION
[#168](https://github.com/chef-cookbooks/chef-splunk/issues/168)

  * uses `node.normal` when `ruby_block[captain elected]` executes to persist that value between chef runs
  * requires manually updating node data to set `node.normal['splunk']['shclustering']['captain_elected'] = true` if you've already deployed v6.2.6 of this cookbook previously; otherwise, skip v6.2.6 and run v6.2.7 directly.

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
https://github.com/chef-cookbooks/chef-splunk/blob/master/recipes/setup_shclustering.rb#L111-L117 sets `node.override['splunk']['shclustering']['captain_elected'] = true`, but the intention is to persist this value between chef runs. `node.override` does not accomplish this. This fix will use `node.normal` to set this value.

### Issues Resolved
<!--- List any existing issues this PR resolves -->
#168 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>