### PR TITLE
- Fixes Issue [#178](https://github.com/chef-cookbooks/chef-splunk/is…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.3.10 (2020-07-15)
+- Fixes Issue [#178](https://github.com/chef-cookbooks/chef-splunk/issues/178)
+- `#shcluster_member?` passes `node['ipaddress']` to `#include?`
+
 ## 6.2.9 (2020-07-01)
 - Drops travis-ci and onboards testing with Github Actions
 - removes dependency on the splunk command when running the `disable` recipe

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -210,7 +210,7 @@ def shcluster_members_ipv4
 end
 
 def shcluster_member?
-  shcluster_members_ipv4.include?
+  shcluster_members_ipv4.include? node['ipaddress']
 end
 
 def shcaptain_elected?

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.2.9'
+version '6.2.10'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'


### PR DESCRIPTION
…sues/178)

- `#shcluster_member?` passes `node['ipaddress']` to `#include?`

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
`#shcluster_member?` was calling ruby method `#include?` and not passing an argument. This fix will pass the node's ipaddress value.

### Issues Resolved
<!--- List any existing issues this PR resolves -->
#178 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>