### PR TITLE
Change default upgrade version to 8.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 6.3.11 (2020-10-14)
+- Sets the Splunk Enterprise Server and Forwarder upgrade versions to 8.0.6
+- Sets the upgrade attributes to pull v8.0.6 of Splunk Enterprise and Universal Forwarder
+
 ## 6.3.10 (2020-07-15)
 - Fixes Issue [#178](https://github.com/chef-cookbooks/chef-splunk/issues/178)
 - `#shcluster_member?` passes `node['ipaddress']` to `#include?`

--- a/attributes/upgrade.rb
+++ b/attributes/upgrade.rb
@@ -2,8 +2,6 @@
 # Cookbook:: chef-splunk
 # Attributes:: upgrade
 #
-# Copyright:: 2014-2019, Chef Software, Inc.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,15 +15,15 @@
 # limitations under the License.
 
 # assumes x86_64 only (is there any reason to test i386 anymore?)
-default['splunk']['forwarder']['upgrade']['version'] = '8.0.1'
-default['splunk']['server']['upgrade']['version'] = '8.0.1'
+default['splunk']['forwarder']['upgrade']['version'] = '8.0.6'
+default['splunk']['server']['upgrade']['version'] = '8.0.6'
 
 default['splunk']['server']['upgrade']['url'] = value_for_platform_family(
-  %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/splunk/releases/8.0.1/linux/splunk-8.0.1-6db836e2fb9e-linux-2.6-x86_64.rpm',
-  'debian' => 'https://download.splunk.com/products/splunk/releases/8.0.1/linux/splunk-8.0.1-6db836e2fb9e-linux-2.6-amd64.deb'
+  %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/splunk/releases/8.0.6/linux/splunk-8.0.6-152fb4b2bb96-linux-2.6-x86_64.rpm',
+  'debian' => 'https://download.splunk.com/products/splunk/releases/8.0.6/linux/splunk-8.0.6-152fb4b2bb96-linux-2.6-amd64.deb'
 )
 
 default['splunk']['forwarder']['upgrade']['url'] = value_for_platform_family(
-  %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/universalforwarder/releases/8.0.1/linux/splunkforwarder-8.0.1-6db836e2fb9e-linux-2.6-x86_64.rpm',
-  'debian' => 'https://download.splunk.com/products/universalforwarder/releases/8.0.1/linux/splunkforwarder-8.0.1-6db836e2fb9e-linux-2.6-amd64.deb'
+  %w(rhel fedora suse amazon) => 'https://download.splunk.com/products/universalforwarder/releases/8.0.6/linux/splunkforwarder-8.0.6-152fb4b2bb96-linux-2.6-x86_64.rpm',
+  'debian' => 'https://download.splunk.com/products/universalforwarder/releases/8.0.6/linux/splunkforwarder-8.0.6-152fb4b2bb96-linux-2.6-amd64.deb'
 )

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.2.10'
+version '6.2.11'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/spec/recipes/upgrade_spec.rb
+++ b/spec/recipes/upgrade_spec.rb
@@ -8,7 +8,7 @@ describe 'chef-splunk::upgrade' do
       node.force_default['splunk']['upgrade_enabled'] = true
       node.force_default['splunk']['accept_license'] = true
       node.force_default['splunk']['server']['upgrade']['url'] = url
-      node.force_default['splunk']['server']['upgrade']['version'] = '8.0.1'
+      node.force_default['splunk']['server']['upgrade']['version'] = '8.0.6'
     end
   end
 
@@ -35,7 +35,7 @@ describe 'chef-splunk::upgrade' do
       chef_run.node.force_default['splunk']['is_server'] = false
       chef_run.node.force_default['splunk']['forwarder']['upgrade']['url'] = ''
       chef_run.converge(described_recipe)
-      expect(chef_run).to upgrade_splunk_installer('splunkforwarder upgrade').with(version: '8.0.1')
+      expect(chef_run).to upgrade_splunk_installer('splunkforwarder upgrade').with(version: '8.0.6')
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
- Sets the Splunk Enterprise Server and Forwarder upgrade versions to 8.0.6
- Sets the upgrade attributes to pull v8.0.6 of Splunk Enterprise and Universal Forwarder

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>