### PR TITLE
Add inspec tests for client kitchen suites

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -117,6 +117,8 @@ suites:
       dev_mode: true
       splunk:
         accept_license: true
+    verifier:
+      name: inspec
 
   - name: uninstall_forwarder
     run_list:

--- a/test/integration/client/linux/client.rb
+++ b/test/integration/client/linux/client.rb
@@ -1,0 +1,21 @@
+# Simple tests for splunk forwarder on linux systems.
+
+describe package('splunkforwarder') do
+  it { should be_installed }
+end
+
+describe service('splunk') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+title 'splunk is listening on 8089'
+describe port 8089 do
+  it { should be_listening }
+  its('protocols') { should include('tcp') }
+end
+
+describe processes('splunkd') do
+  it { should exist }
+end


### PR DESCRIPTION
### Description

Adding tests that show, that systemd does not show splunk as running.

### Issues Resolved
Example Tests for issue #185. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>