### PR TITLE
sets umask when executing the `execute[splunk enable boot-start]`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,44 +64,6 @@ jobs:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
 
-  # dokken:
-  #   needs: [yamllint, delivery]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - 'debian-10'
-  #         - 'centos-8'
-  #         - 'ubuntu-2004'
-  #       suite:
-  #         - 'client'
-  #         - 'uninstall-forwarder'
-  #         - 'client-inputs-outputs'
-  #         - 'server-runas-root'
-  #         - 'server-cluster-master'
-  #         - 'server-shdeployer'
-  #         - 'server-shcluster-member'
-  #         - 'disabled'
-  #         - 'upgrade-server'
-  #         - 'upgrade-client'
-  #         - 'server-resources'
-  #         - 'client-resources'
-  #     fail-fast: false
-  #
-  #   steps:
-  #     - name: Check out code
-  #       uses: actions/checkout@master
-  #     - name: Install Chef
-  #       uses: actionshub/chef-install@master
-  #     - name: Dokken
-  #       uses: actionshub/kitchen-dokken@master
-  #       env:
-  #         CHEF_LICENSE: accept-no-persist
-  #         KITCHEN_LOCAL_YAML: test/kitchen/kitchen.dokken.yml
-  #       with:
-  #         suite: ${{ matrix.suite }}
-  #         os: ${{ matrix.os }}
-
   final:
     needs: [vagrant]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Run yaml Lint
         uses: actionshub/yamllint@master
 
-  dokken:
+  vagrant:
     needs: [yamllint, delivery]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         os:
@@ -55,17 +55,55 @@ jobs:
         uses: actions/checkout@master
       - name: Install Chef
         uses: actionshub/chef-install@master
-      - name: Dokken
-        uses: actionshub/kitchen-dokken@master
+      - name: Test Kitchen
+        uses: actionshub/test-kitchen@master
         env:
           CHEF_LICENSE: accept-no-persist
-          KITCHEN_LOCAL_YAML: test/kitchen/kitchen.dokken.yml
+          KITCHEN_LOCAL_YAML: test/kitchen/kitchen.vagrant.yml
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
 
+  # dokken:
+  #   needs: [yamllint, delivery]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       os:
+  #         - 'debian-10'
+  #         - 'centos-8'
+  #         - 'ubuntu-2004'
+  #       suite:
+  #         - 'client'
+  #         - 'uninstall-forwarder'
+  #         - 'client-inputs-outputs'
+  #         - 'server-runas-root'
+  #         - 'server-cluster-master'
+  #         - 'server-shdeployer'
+  #         - 'server-shcluster-member'
+  #         - 'disabled'
+  #         - 'upgrade-server'
+  #         - 'upgrade-client'
+  #         - 'server-resources'
+  #         - 'client-resources'
+  #     fail-fast: false
+  #
+  #   steps:
+  #     - name: Check out code
+  #       uses: actions/checkout@master
+  #     - name: Install Chef
+  #       uses: actionshub/chef-install@master
+  #     - name: Dokken
+  #       uses: actionshub/kitchen-dokken@master
+  #       env:
+  #         CHEF_LICENSE: accept-no-persist
+  #         KITCHEN_LOCAL_YAML: test/kitchen/kitchen.dokken.yml
+  #       with:
+  #         suite: ${{ matrix.suite }}
+  #         os: ${{ matrix.os }}
+
   final:
-    needs: [dokken]
+    needs: [vagrant]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ lib/bundler/man
 pkg
 test/tmp
 test/version_tmp
-test/kitchen/kitchen.ec2.yml
-test/kitchen/user-data.sh
 tmp
 _Store
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 7.0.0 (2020-10-22)
+**BREAKING CHANGE**
+- sets umask when executing the `execute[splunk enable boot-start]` resource
+- adds new attribute, `default['splunk']['enable_boot_start_umask']` for umask setting applied to `execute[splunk enable boot-start]` (Default: '18')
+- `#splunk_cmd` now requires a dynamic array of arguments that will be appended to the splunk command
+- `splunk.service` is symlinked to the systemd unit
+- adds a kitchen-vagrant config to run inside Github Actions
+
 ## 6.4.1 (2020-10-20)
 - Fixes an issue running Splunk and the Splunk Universal Forwarder as a non-root user
 - Fixes Test Kitchen configuration to test running Splunk as non-root user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file is used to list changes made in each version of the splunk cookbook.
 - `#splunk_cmd` now requires a dynamic array of arguments that will be appended to the splunk command
 - `splunk.service` is symlinked to the systemd unit
 - adds a kitchen-vagrant config to run inside Github Actions
+- enhancements to the `:remove` action for `splunk_installer` resource to ensure a complete uninstall for both Splunk Enterprise Server and Universal Forwarder
 
 ## 6.4.1 (2020-10-20)
 - Fixes an issue running Splunk and the Splunk Universal Forwarder as a non-root user

--- a/README.md
+++ b/README.md
@@ -326,6 +326,30 @@ must be set explicitly elsewhere on the node(s).
   node.force_default['splunk']['server']['upgrade']['url'] = nil
   ```
 
+## Helper methods
+### splunk_cmd
+When wrapping this cookbook, it is often beneficial to run Splunk Enterprise or Universal Forwarder as a non-root user. This is, in fact, a security recommendation to run Splunk as a non-root user. To this end, `#splunk_cmd` will return the properly constructed command to run a Splunk CLI command with arguments.
+
+Example:
+```
+execute 'set servername' do
+  command splunk_cmd(['set', 'servername', node.name, '-auth', node.run_state['splunk_auth_info'])
+  sensitive true
+  notifies :restart, 'service[splunk]'
+end
+```
+
+another way that will result in the same command:
+
+```
+execute 'set servername' do
+  command splunk_cmd("set servname #{node.name} -auth '#{node.run_state['splunk_auth_info']}'")
+  sensitive true
+  notifies :restart, 'service[splunk]'
+end
+```
+
+
 ## Custom Resources
 
 ### splunk_app

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['splunk']['web_port']       = '443'
 default['splunk']['ratelimit_kilobytessec'] = '2048'
 default['splunk']['disabled'] = false
 default['splunk']['data_bag'] = 'vault'
+default['splunk']['enable_boot_start_umask'] = '18'
 
 default['splunk']['setup_auth'] = true
 default['splunk']['service_name'] = 'splunk' # Splunk changes this to Splunkd or SplunkForwarder on systemd-managed servers

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -121,8 +121,8 @@ suites:
         clustering:
           enabled: true
           mode: master
-          replication_factor: 5
-          search_factor: 3
+          replication_factor: 2
+          search_factor: 1
     verifier:
       name: inspec
       inspec_tests:

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '6.4.1'
+version '7.0.0'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -42,7 +42,8 @@ server_list = if !(node['splunk']['server_list'].nil? || node['splunk']['server_
 # if the splunk daemon is running as root, executing a normal service restart or stop will fail if the boot
 # start script has been modified to execute splunk as a non-root user.
 # So, the splunk daemon must be run this way instead
-execute "#{splunk_cmd} stop" do
+execute 'splunk stop' do
+  command splunk_cmd('stop')
   action :nothing
   not_if { node['splunk']['server']['runasroot'] == true }
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -24,7 +24,7 @@ include_recipe 'chef-splunk::service'
 include_recipe 'chef-splunk::setup_auth' if setup_auth?
 
 execute 'update-splunk-mgmt-port' do
-  command "#{splunk_cmd} set splunkd-port #{node['splunk']['mgmt_port']} -auth '#{node.run_state['splunk_auth_info']}'"
+  command splunk_cmd("set splunkd-port #{node['splunk']['mgmt_port']} -auth '#{node.run_state['splunk_auth_info']}'")
   sensitive true unless Chef::Log.debug?
   not_if { current_mgmt_port == node['splunk']['mgmt_port'] }
   notifies :restart, 'service[splunk]' unless disabled?
@@ -33,7 +33,7 @@ end
 ruby_block 'enable-splunk-receiver-port' do
   sensitive true unless Chef::Log.debug?
   block do
-    splunk = Mixlib::ShellOut.new("#{splunk_cmd} enable listen #{node['splunk']['receiver_port']} -auth #{node.run_state['splunk_auth_info']}")
+    splunk = Mixlib::ShellOut.new(splunk_cmd("enable listen #{node['splunk']['receiver_port']} -auth #{node.run_state['splunk_auth_info']}"))
     splunk.run_command
     true if splunk.stderr.include?("Configuration for port #{node['splunk']['receiver_port']} already exists")
   end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -77,7 +77,7 @@ file '/etc/init.d/splunk' do
   only_if { systemd? }
 end
 
-execute 'splunk enable boot-start' do
+execute "splunk #{disabled? ? 'disable' : 'enable' } boot-start" do
   command boot_start_cmd
   sensitive false
   retries 3

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -78,7 +78,7 @@ file '/etc/init.d/splunk' do
 end
 
 execute "splunk #{disabled? ? 'disable' : 'enable'} boot-start" do
-  command boot_start_cmd
+  command boot_start_cmd(disabled? ? true : nil)
   sensitive false
   retries 3
   creates node['splunk']['startup_script']

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -66,7 +66,8 @@ end
 # if the splunk daemon is running as root, executing a normal service restart or stop will fail if the boot
 # start script has been modified to execute splunk as a non-root user.
 # So, the splunk daemon must be run this way instead
-execute "#{splunk_cmd} stop" do
+execute 'splunk stop' do
+  command splunk_cmd('stop')
   action :nothing
   subscribes :run, 'execute[splunk enable boot-start]', :before
 end
@@ -81,6 +82,11 @@ execute 'splunk enable boot-start' do
   sensitive false
   retries 3
   creates node['splunk']['startup_script']
+  umask node['splunk']['enable_boot_start_umask']
+end
+
+link '/etc/systemd/system/splunk.service' do
+  to server? ? '/etc/systemd/system/Splunkd.service' : '/etc/systemd/system/SplunkForwarder.service'
 end
 
 default_service_action = if node['splunk']['disabled'] == true
@@ -95,8 +101,11 @@ service 'splunk' do
   service_name node['splunk']['service_name']
   action default_service_action
   supports status: true, restart: true
-  status_command "#{splunk_dir}/bin/splunk status"
+  status_command svc_command('status')
   timeout 1800
   provider splunk_service_provider
-  subscribes :restart, 'template[user-seed.conf]', :immediately unless disabled?
+  unless disabled?
+    subscribes :restart, 'template[user-seed.conf]', :immediately
+    subscribes :restart, "user[#{node['splunk']['user']['username']}]", :immediately
+  end
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -77,7 +77,7 @@ file '/etc/init.d/splunk' do
   only_if { systemd? }
 end
 
-execute "splunk #{disabled? ? 'disable' : 'enable' } boot-start" do
+execute "splunk #{disabled? ? 'disable' : 'enable'} boot-start" do
   command boot_start_cmd
   sensitive false
   retries 3

--- a/recipes/setup_auth.rb
+++ b/recipes/setup_auth.rb
@@ -30,7 +30,7 @@ include_recipe 'chef-splunk'
 _user, pw = node.run_state['splunk_auth_info'].split(':')
 
 file '.user-seed.conf' do
-  action :nothing
+  action splunk_login_successful? ? :nothing : :delete
   path "#{splunk_dir}/etc/system/local/.user-seed.conf"
   subscribes :touch, 'file[user-seed.conf]', :immediately
 end

--- a/recipes/setup_clustering.rb
+++ b/recipes/setup_clustering.rb
@@ -68,7 +68,7 @@ end
 splunk_cmd_params << " -secret #{node.run_state['splunk_secret']}" if node.run_state['splunk_secret']
 
 execute 'setup-indexer-cluster' do
-  command "#{splunk_cmd} edit cluster-config #{splunk_cmd_params} -auth '#{node.run_state['splunk_auth_info']}'"
+  command splunk_cmd("edit cluster-config #{splunk_cmd_params} -auth '#{node.run_state['splunk_auth_info']}'")
   sensitive true unless Chef::Log.debug?
   not_if { ::File.exist?("#{splunk_dir}/etc/.setup_clustering") }
   notifies :start, 'service[splunk]', :before unless disabled?

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -16,20 +16,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 group node['splunk']['user']['username'] do
+  action :nothing
   gid node['splunk']['user']['uid'].to_i # CHEF-4927
   system true if %w(linux).include?(node['os'])
-end
+end.run_action(:create)
 
 node.default['splunk']['user']['home'] = splunk_dir
 
 user node['splunk']['user']['username'] do
+  action :nothing
   comment node['splunk']['user']['comment']
   shell node['splunk']['user']['shell']
   gid node['splunk']['user']['username']
   uid node['splunk']['user']['uid']
   home node['splunk']['user']['home']
   system true if %w(linux).include?(node['os'])
-  notifies :stop, 'service[splunk]', :before if splunk_installed?
-end
+end.run_action(:create)

--- a/spec/recipes/disabled_spec.rb
+++ b/spec/recipes/disabled_spec.rb
@@ -6,8 +6,8 @@ describe 'chef-splunk::disabled' do
       ChefSpec::ServerRunner.new do |node, server|
         create_data_bag_item(server, 'vault', 'splunk__default')
         node.force_default['splunk']['disabled'] = true
+        node.force_default['splunk']['accept_license'] = true
         allow_any_instance_of(Chef::Recipe).to receive(:splunk_installed?).and_return(true)
-        allow_any_instance_of(Chef::Recipe).to receive(:license_accepted?).and_return(true)
       end.converge(described_recipe)
     end
 

--- a/spec/recipes/setup_auth_spec.rb
+++ b/spec/recipes/setup_auth_spec.rb
@@ -34,7 +34,7 @@ describe 'chef-splunk::setup_auth' do
       end
 
       it 'created .user-seed.conf only when notified after user-seed.conf is processed' do
-        expect(chef_run).to nothing_file('.user-seed.conf')
+        expect(chef_run).to delete_file('.user-seed.conf')
         expect(chef_run.file('.user-seed.conf')).to subscribe_to('file[user-seed.conf]').on(:touch).immediately
       end
     end

--- a/spec/recipes/setup_clustering_spec.rb
+++ b/spec/recipes/setup_clustering_spec.rb
@@ -8,8 +8,9 @@ shared_examples 'a successful run' do |params|
     expect(chef_run.execute('setup-indexer-cluster')).to notify('service[splunk]').to(:restart)
   end
 
-  it 'writes a file marker to ensure convergence' do
-    expect(chef_run).to create_file('/opt/splunk/etc/.setup_clustering')
+  it 'writes a file marker to indicate no setup for clustering is needed (i.e., already done)' do
+    expect(chef_run).to nothing_file('/opt/splunk/etc/.setup_clustering')
+    expect(chef_run.file('/opt/splunk/etc/.setup_clustering')).to subscribe_to('execute[setup-indexer-cluster]').on(:touch).delayed
   end
 end
 

--- a/test/fixtures/cookbooks/test/recipes/uninstall_forwarder.rb
+++ b/test/fixtures/cookbooks/test/recipes/uninstall_forwarder.rb
@@ -4,19 +4,19 @@ include_recipe 'chef-splunk::install_forwarder'
 
 # this ruby_block is necessary to effectively mitigate notifications sent from other
 # resources to the service[splunk] service and the execute[/opt/splunkforwarder/bin/splunk stop]
-ruby_block 'mitigation splunk service notifications' do
-  block do
-    r = resources('service[splunk]')
-    r.restart_command('/bin/true')
-    r.stop_command('/bin/true')
-    r.start_command('/bin/true')
-    r.status_command('/bin/true')
-  end
-end
+# ruby_block 'mitigation splunk service notifications' do
+#   block do
+#     r = resources('service[splunk]')
+#     r.restart_command('/bin/true')
+#     r.stop_command('/bin/true')
+#     r.start_command('/bin/true')
+#     r.status_command('/bin/true')
+#   end
+# end
 
 splunk_installer 'splunkforwarder' do
   url node['splunk']['forwarder']['url']
   version node['splunk']['forwarder']['version']
-  action :remove
-  notifies :stop, 'service[splunk]', :before if splunk_installed?
+  action :nothing
+  subscribes :remove, 'service[splunk]'
 end

--- a/test/fixtures/cookbooks/test/recipes/uninstall_forwarder.rb
+++ b/test/fixtures/cookbooks/test/recipes/uninstall_forwarder.rb
@@ -11,9 +11,6 @@ ruby_block 'mitigation splunk service notifications' do
     r.stop_command('/bin/true')
     r.start_command('/bin/true')
     r.status_command('/bin/true')
-
-    r = resources('execute[/opt/splunkforwarder/bin/splunk stop]')
-    r.command('/bin/true')
   end
 end
 

--- a/test/integration/inspec/client_test.rb
+++ b/test/integration/inspec/client_test.rb
@@ -94,22 +94,3 @@ control 'Splunk Universal Forwarder' do
     end
   end
 end
-
-control 'Splunk admin password validation' do
-  title 'Splunk admin password'
-  desc 'validate that the splunk admin password has been properly set'
-
-  describe file("#{SPLUNK_HOME}/etc/system/local/user-seed.conf") do
-    it { should_not exist }
-  end
-
-  describe file("#{SPLUNK_HOME}/etc/system/local/.user-seed.conf") do
-    it { should exist }
-  end
-
-  # the password used for validation here is from the test/fixture/data_bags/vault/splunk__default.rb
-  describe command("#{SPLUNK_HOME}/bin/splunk validate-passwd notarealpassword") do
-    its('stderr') { should be_empty }
-    its('exit_status') { should eq 0 }
-  end
-end

--- a/test/integration/inspec/server_cluster_master_test.rb
+++ b/test/integration/inspec/server_cluster_master_test.rb
@@ -7,7 +7,8 @@ control 'Splunk Cluster Master' do
   end
 
   describe ini('/opt/splunk/etc/system/local/inputs.conf') do
-    its('default.host') { should eq 'dokken' }
+    its('default.host') { should_not be_nil }
+    its('default.host') { should_not be_empty }
   end
 
   describe file('/opt/splunk/etc/system/local/server.conf') do

--- a/test/integration/inspec/uninstall_forwarder_test.rb
+++ b/test/integration/inspec/uninstall_forwarder_test.rb
@@ -10,6 +10,22 @@ control 'Splunk Universal Forwarder' do
     it { should_not be_installed }
   end
 
+  describe user('splunk') do
+    it { should_not exist }
+  end
+
+  describe group('splunk') do
+    it { should_not exist }
+  end
+
+  describe directory('/opt/splunkforwarder') do
+    it { should_not exist }
+  end
+
+  describe processes(Regexp.new('splunkd')) do
+    it { should_not exist }
+  end
+
   describe.one do
     describe service('SplunkForwarder') do
       it { should_not be_running }

--- a/test/integration/inspec/uninstall_forwarder_test.rb
+++ b/test/integration/inspec/uninstall_forwarder_test.rb
@@ -11,12 +11,15 @@ control 'Splunk Universal Forwarder' do
   end
 
   describe.one do
-    %w(splunk SplunkForwarder).each do |svc|
-      describe service svc do
-        it { should_not be_running }
-        it { should_not be_enabled }
-        it { should_not be_installed }
-      end
+    describe service('SplunkForwarder') do
+      it { should_not be_running }
+      it { should_not be_enabled }
+      it { should_not be_installed }
+    end
+    describe service('splunk') do
+      it { should_not be_running }
+      it { should_not be_enabled }
+      it { should_not be_installed }
     end
   end
 end

--- a/test/integration/inspec/upgrade_test.rb
+++ b/test/integration/inspec/upgrade_test.rb
@@ -19,12 +19,20 @@ control 'Splunk Upgrade' do
   end
 
   describe.one do
-    %w(Splunkd SplunkForwarder splunk).each do |svc|
-      describe service(svc) do
-        it { should be_installed }
-        it { should be_enabled }
-        it { should be_running }
-      end
+    describe service('Splunkd') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+    describe service('SplunkForwarder') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+    describe service('splunk') do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
     end
   end
 end

--- a/test/kitchen/kitchen.dokken.yml
+++ b/test/kitchen/kitchen.dokken.yml
@@ -17,7 +17,7 @@ transport:
 # so we force a wait after converging the node
 lifecycle:
   post_converge:
-    - local: sleep 240
+    - local: sleep 300
 
 platforms:
   - name: debian-10

--- a/test/kitchen/kitchen.vagrant.yml
+++ b/test/kitchen/kitchen.vagrant.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: vagrant
+  boot_timeout: 600
 
 provisioner:
   name: chef_zero

--- a/test/kitchen/kitchen.vagrant.yml
+++ b/test/kitchen/kitchen.vagrant.yml
@@ -1,0 +1,23 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: debian-10
+    driver:
+      pid_one_command: /sbin/init
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
+  - name: centos-8
+    driver:
+      pid_one_command: /usr/lib/systemd/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
+  - name: ubuntu-20.04
+    driver:
+      pid_one_command: /bin/systemd


### PR DESCRIPTION
- sets umask when executing the `execute[splunk enable boot-start]` resource
- adds new attribute, `default['splunk']['enable_boot_start_umask']` for umask setting applied to `execute[splunk enable boot-start]` (Default: 18)

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
The `splunk enable boot-start` command is failing systemd verification on some systems with restrictive system-wide umask, such as `077`. This change sets the umask to `022` when running the command.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>