### PR TITLE
Expand and correct suite failures so all supported OSes are covered + split suites between Vagrant and Dokken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,26 +26,20 @@ jobs:
       - name: Run yaml Lint
         uses: actionshub/yamllint@master
 
+  # Vagrant tests are very slow and often time out, so only check those services that
+  # don't run as root across centos and debian, ubuntu.
   vagrant:
     needs: [yamllint, delivery]
     runs-on: macos-latest
     strategy:
       matrix:
         os:
-          - 'debian-10'
-          - 'debian-9'
           - 'centos-8'
-          - 'centos-7'
+          - 'debian-10'
           - 'ubuntu-2004'
-          - 'ubuntu-1804'
-          - 'ubuntu-1604'
         suite:
-          - 'server-runas-root'
-          - 'server-cluster-master'
-          - 'server-shdeployer'
-          - 'server-shcluster-member'
-          - 'upgrade-server'
-          - 'server-resources'
+          - 'client-runas-splunk'
+          - 'server-runas-splunk'
       fail-fast: false
 
     steps:
@@ -62,28 +56,33 @@ jobs:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
 
-  # Run client & disabled tests in dokken as docker is quicker.
+  # Run most tests in dokken as it's quicker than Vagrant
   dokken:
     needs: [yamllint, delivery]
     runs-on: macos-latest
     strategy:
       matrix:
         os:
+          - 'centos-7'
+          - 'centos-8'
           - 'debian-10'
           - 'debian-9'
-          - 'centos-8'
-          - 'centos-7'
-          - 'centos-6'
-          - 'ubuntu-2004'
-          - 'ubuntu-1804'
           - 'ubuntu-1604'
+          - 'ubuntu-1804'
+          - 'ubuntu-2004'
         suite:
           - 'client'
-          - 'uninstall-forwarder'
           - 'client-inputs-outputs'
-          - 'disabled'
-          - 'upgrade-client'
           - 'client-resources'
+          - 'disabled'
+          - 'server-cluster-master'
+          - 'server-resources'
+          - 'server-runas-root'
+          - 'server-shcluster-member'
+          - 'server-shdeployer'
+          - 'uninstall-forwarder'
+          - 'upgrade-client'
+          - 'upgrade-server'
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         suite:
           - 'client-runas-splunk'
           - 'server-runas-splunk'
+          # Run the server in Vagrant too, as it splunk often does not keep running in Dokken.
+          - 'server-runas-root'
       fail-fast: false
 
     steps:
@@ -74,7 +76,6 @@ jobs:
           - 'disabled'
           - 'server-cluster-master'
           - 'server-resources'
-          - 'server-runas-root'
           - 'server-shcluster-member'
           - 'server-shdeployer'
           - 'uninstall-forwarder'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,49 @@ jobs:
           - 'ubuntu-1804'
           - 'ubuntu-1604'
         suite:
-          - 'client'
-          - 'uninstall-forwarder'
-          - 'client-inputs-outputs'
           - 'server-runas-root'
           - 'server-cluster-master'
           - 'server-shdeployer'
           - 'server-shcluster-member'
-          - 'disabled'
           - 'upgrade-server'
-          - 'upgrade-client'
           - 'server-resources'
+      fail-fast: false
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Install Chef
+        uses: actionshub/chef-install@master
+      - name: Test Kitchen
+        uses: actionshub/test-kitchen@master
+        env:
+          CHEF_LICENSE: accept-no-persist
+          KITCHEN_LOCAL_YAML: test/kitchen/kitchen.vagrant.yml
+        with:
+          suite: ${{ matrix.suite }}
+          os: ${{ matrix.os }}
+
+  # Run client & disabled tests in dokken as docker is quicker.
+  dokken:
+    needs: [yamllint, delivery]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        os:
+          - 'debian-10'
+          - 'debian-9'
+          - 'centos-8'
+          - 'centos-7'
+          - 'centos-6'
+          - 'ubuntu-2004'
+          - 'ubuntu-1804'
+          - 'ubuntu-1604'
+        suite:
+          - 'client'
+          - 'uninstall-forwarder'
+          - 'client-inputs-outputs'
+          - 'disabled'
+          - 'upgrade-client'
           - 'client-resources'
       fail-fast: false
 
@@ -68,8 +100,9 @@ jobs:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
 
+
   final:
-    needs: [vagrant]
+    needs: [vagrant, dokken]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   # Run most tests in dokken as it's quicker than Vagrant
   dokken:
     needs: [yamllint, delivery]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
@@ -94,11 +94,10 @@ jobs:
         uses: actionshub/test-kitchen@master
         env:
           CHEF_LICENSE: accept-no-persist
-          KITCHEN_LOCAL_YAML: test/kitchen/kitchen.vagrant.yml
+          KITCHEN_LOCAL_YAML: test/kitchen/kitchen.dokken.yml
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
-
 
   final:
     needs: [vagrant, dokken]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
----
 name: ci
 
 on:
@@ -26,10 +25,9 @@ jobs:
       - name: Run yaml Lint
         uses: actionshub/yamllint@master
 
-  # Vagrant tests are very slow and often time out, so only check those services that
-  # don't run as root across centos and debian, ubuntu.
+  # Vagrant tests are very slow and often time out, so only check those suites that
+  # don't run as root across latest centos, debian and ubuntu.
   vagrant:
-    needs: [yamllint, delivery]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -58,7 +56,6 @@ jobs:
 
   # Run most tests in dokken as it's quicker than Vagrant
   dokken:
-    needs: [yamllint, delivery]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -98,10 +95,3 @@ jobs:
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}
-
-  final:
-    needs: [vagrant, dokken]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,12 @@ jobs:
       matrix:
         os:
           - 'debian-10'
+          - 'debian-9'
           - 'centos-8'
+          - 'centos-7'
           - 'ubuntu-2004'
+          - 'ubuntu-1804'
+          - 'ubuntu-1604'
         suite:
           - 'client'
           - 'uninstall-forwarder'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 7.0.1 (unreleased)
+- Moves most tests back to dokken and only run suites that change splunk user from root in vagrant.
+
 ## 7.0.0 (2020-10-22)
 **BREAKING CHANGE**
 - sets umask when executing the `execute[splunk enable boot-start]` resource

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -84,6 +84,9 @@ suites:
                 source: tcp:123123
 
   - name: server-runas-root
+    lifecycle:
+      post_converge:
+        - local: sleep 120
     run_list:
       - recipe[test::file_locking_check]
       - recipe[chef-splunk::default]
@@ -97,6 +100,9 @@ suites:
         - path: test/integration/inspec/server_test.rb
 
   - name: server-runas-splunk
+    lifecycle:
+      post_converge:
+        - local: sleep 120
     run_list:
       - recipe[chef-splunk::default]
     attributes:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -46,7 +46,7 @@ suites:
       inspec_tests:
         - path: test/integration/inspec/client_test.rb
 
-  - name: uninstall_forwarder
+  - name: uninstall-forwarder
     run_list:
       - recipe[test::uninstall_forwarder]
     attributes:
@@ -162,7 +162,6 @@ suites:
       - recipe[chef-splunk::default]
       - recipe[chef-splunk::disabled]
     attributes:
-    attributes:
       splunk:
         is_server: true
         accept_license: true
@@ -172,7 +171,7 @@ suites:
       inspec_tests:
         - path: test/integration/inspec/disabled_test.rb
 
-  - name: upgrade_server
+  - name: upgrade-server
     run_list:
       - recipe[test::file_locking_check]
       - recipe[test::upgrade]
@@ -187,7 +186,7 @@ suites:
       inspec_tests:
         - path: test/integration/inspec/upgrade_test.rb
 
-  - name: upgrade_client
+  - name: upgrade-client
     run_list:
       - recipe[test::file_locking_check]
       - recipe[test::upgrade]

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '7.0.0'
+version '7.0.1'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'

--- a/test/integration/inspec/server_test.rb
+++ b/test/integration/inspec/server_test.rb
@@ -42,12 +42,12 @@ control 'Enterprise Splunk' do
   end
 
   describe.one do
-    describe processes(/splunkd.*-p 8089 _internal_launch_under_systemd/) do
+    describe processes(Regexp.new('splunkd.*-p 8089 _internal_launch_under_systemd')) do
       its('users') { should include 'splunk' }
       its('users') { should_not include 'root' }
       it { should exist }
     end
-    describe processes(/splunkd.*-p 8089 _internal_launch_under_systemd/) do
+    describe processes(Regexp.new('splunkd.*-p 8089 _internal_launch_under_systemd')) do
       its('users') { should include 'root' }
       it { should exist }
     end

--- a/test/integration/inspec/server_test.rb
+++ b/test/integration/inspec/server_test.rb
@@ -79,9 +79,18 @@ control 'Splunk admin password validation' do
     it { should exist }
   end
 
-  # the password used for validation here is from the test/fixture/data_bags/vault/splunk__default.rb
-  describe command("#{SPLUNK_HOME}/bin/splunk login -auth admin:notarealpassword") do
-    its('stderr') { should be_empty }
-    its('exit_status') { should eq 0 }
+  describe.one do
+    # the password used for validation here is from the test/fixture/data_bags/vault/splunk__default.rb
+    describe command("#{SPLUNK_HOME}/bin/splunk login -auth admin:notarealpassword") do
+      its('stderr') { should be_empty }
+      its('exit_status') { should eq 0 }
+    end
+
+    # When running as a service user, need to check logging into splunk as the service user or
+    # you get a permission denied when writing the token to ~/.splunk/.
+    describe command("sudo -u splunk #{SPLUNK_HOME}/bin/splunk login -auth admin:notarealpassword") do
+      its('stderr') { should be_empty }
+      its('exit_status') { should eq 0 }
+    end
   end
 end

--- a/test/kitchen/kitchen.dokken.yml
+++ b/test/kitchen/kitchen.dokken.yml
@@ -13,16 +13,17 @@ provisioner:
 transport:
   name: dokken
 
-# splunkd takes a little time to be fully ready for Inspec
-# so we force a wait after converging the node
-lifecycle:
-  post_converge:
-    - local: sleep 300
-
 platforms:
   - name: debian-10
     driver:
       image: dokken/debian-10
+      pid_one_command: /sbin/init
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
+  - name: debian-9
+    driver:
+      image: dokken/debian-9
       pid_one_command: /sbin/init
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
@@ -34,7 +35,31 @@ platforms:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
+  - name: centos-6
+    driver:
+      image: dokken/centos-6
+      pid_one_command: /sbin/init
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-16.04
+    driver:
+      image: dokken/ubuntu-16.04
       pid_one_command: /bin/systemd

--- a/test/kitchen/kitchen.dokken.yml
+++ b/test/kitchen/kitchen.dokken.yml
@@ -42,13 +42,6 @@ platforms:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
-  - name: centos-6
-    driver:
-      image: dokken/centos-6
-      pid_one_command: /sbin/init
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
-
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04

--- a/test/kitchen/kitchen.dokken.yml
+++ b/test/kitchen/kitchen.dokken.yml
@@ -17,14 +17,14 @@ platforms:
   - name: debian-10
     driver:
       image: dokken/debian-10
-      pid_one_command: /sbin/init
+      pid_one_command: /bin/systemd
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
   - name: debian-9
     driver:
       image: dokken/debian-9
-      pid_one_command: /sbin/init
+      pid_one_command: /bin/systemd
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 

--- a/test/kitchen/kitchen.vagrant.yml
+++ b/test/kitchen/kitchen.vagrant.yml
@@ -13,12 +13,32 @@ platforms:
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
+  - name: debian-9
+    driver:
+      pid_one_command: /sbin/init
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
   - name: centos-8
     driver:
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
+  - name: centos-7
+    driver:
+      pid_one_command: /usr/lib/systemd/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
   - name: ubuntu-20.04
+    driver:
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-18.04
+    driver:
+      pid_one_command: /bin/systemd
+
+  - name: ubuntu-16.04
     driver:
       pid_one_command: /bin/systemd


### PR DESCRIPTION
### Description
- Add missing supported OSes from the test matrix (Fixes: #194).
- Move all suites expect those that don't run as root back to dokken, as running as non-root fails in dokken.
- Add missing suites from the kitchen config to the matrix. 
- Remove `post_converge` from the dokken config, as it's gone from the vagrant config.
- Ensure same platforms are listed in the dokken and vagrant kitchen configs.
- Bump version to 7.0.1 and log changes.
- Sync up the suite names in ci workflow and suites (change `_` to `-`).
- Correct test failure for `server-runas-splunk` where command failed due to permission error writing to `/root/.splunk/`.

### Issues Resolved
- That tests are carried out on more supported OSes (expect `centos-6`, as it's EoL on 2020-11-30).

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
