### PR TITLE
Only link /etc/systemd/system/splunk.service running on systemd

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -87,6 +87,7 @@ end
 
 link '/etc/systemd/system/splunk.service' do
   to server? ? '/etc/systemd/system/Splunkd.service' : '/etc/systemd/system/SplunkForwarder.service'
+  only_if { systemd? }
 end
 
 default_service_action = if node['splunk']['disabled'] == true


### PR DESCRIPTION
### Description
- Add an `only_if` to only create systemd symlinks on systemd systems.

### Issues Resolved
- Converge failures on centos-6 for creating link for systemd.

```
  * link[/etc/systemd/system/splunk.service] action create

    ================================================================================
    Error executing action `create` on resource 'link[/etc/systemd/system/splunk.service]'
    ================================================================================

    Errno::ENOENT
    -------------
    No such file or directory @ rb_file_s_symlink - (/etc/systemd/system/SplunkForwarder.service, /etc/systemd/system/splunk.service)

    Resource Declaration:
    ---------------------
    # In /opt/kitchen/cache/cookbooks/chef-splunk/recipes/service.rb

     88: link '/etc/systemd/system/splunk.service' do
     89:   to server? ? '/etc/systemd/system/Splunkd.service' : '/etc/systemd/system/SplunkForwarder.service'
     90:   not_if { systemd? }
     91: end
     92:

    Compiled Resource:
    ------------------
    # Declared in /opt/kitchen/cache/cookbooks/chef-splunk/recipes/service.rb:88:in `from_file'

    link("/etc/systemd/system/splunk.service") do
      action [:create]
      default_guard_interpreter :default
      declared_type :link
      cookbook_name "chef-splunk"
      recipe_name "service"
      to "/etc/systemd/system/SplunkForwarder.service"
      target_file "/etc/systemd/system/splunk.service"
      not_if { #code block }
    end

    System Info:
    ------------
    chef_version=16.6.14
    platform=centos
    platform_version=6.10
    ruby=ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
    program_name=/opt/chef/bin/chef-client
    executable=/opt/chef/bin/chef-client
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>