### PR TITLE
Adds optional support for tagging EC2 instances to rotate Splunk secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@master
+        uses: actionshub/chef-delivery@main
         env:
           CHEF_LICENSE: accept-no-persist
 
@@ -23,7 +23,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Run yaml Lint
-        uses: actionshub/yamllint@master
+        uses: actionshub/yamllint@main
 
   # Vagrant tests are very slow and often time out, so only check those suites that
   # don't run as root across latest centos, debian and ubuntu.
@@ -46,7 +46,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Install Chef
-        uses: actionshub/chef-install@master
+        uses: actionshub/chef-install@main
       - name: Test Kitchen
         uses: actionshub/test-kitchen@master
         env:
@@ -87,7 +87,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Install Chef
-        uses: actionshub/chef-install@master
+        uses: actionshub/chef-install@main
       - name: Test Kitchen
         uses: actionshub/test-kitchen@master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of the splunk cookbook.
 
+## 7.1.0 (2020-11-30)
+- Adds cookbook dependency on [ec2-tags-ohai-plugin](https://supermarket.chef.io/cookbooks/ec2-tags-ohai-plugin) to read EC2 tags as a secondary detection method for rotating Splunk secrets
+
 ## 7.0.3 (2020-11-02)
 - Fixes Issue #128 logic in `#shcluster_members?` helper method with a better match
 

--- a/libraries/splunk_secrets_helper.rb
+++ b/libraries/splunk_secrets_helper.rb
@@ -6,7 +6,7 @@ module SecretsHelper
     key = nil
     tag = "force_#{section}_#{secret_name.downcase}_rotation"
 
-    if node.tags.include?(tag) || file.nil?
+    if node.tags.include?(tag) || (node.respond_to?('ec2') && node.ec2.tags && node.ec2.tags.include?(tag)) || file.nil?
       ::Chef::Log.info("secret rotation occurred for #{secret_name.downcase} in [#{section}]")
       node.tags.delete(tag)
     elsif ::File.exist?(file)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Manage Splunk Enterprise or Splunk Universal Forwarder'
-version '7.0.3'
+version '7.1.0'
 
 supports 'debian', '>= 8.9'
 supports 'ubuntu', '>= 16.04'
@@ -14,6 +14,7 @@ supports 'amazon'
 # please read the README.md section regarding data bag fallback if you
 # do not use chef-vault
 depends 'chef-vault', '~> 4.0'
+depends 'ec2-tags-ohai-plugin', '~> 0.2.4'
 
 source_url 'https://github.com/chef-cookbooks/chef-splunk'
 issues_url 'https://github.com/chef-cookbooks/chef-splunk/issues'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,8 @@ vault_item = chef_vault_item(node['splunk']['data_bag'], "splunk_#{node.chef_env
 node.run_state['splunk_auth_info'] = splunk_auth(vault_item['auth'])
 node.run_state['splunk_secret'] = vault_item['secret']
 
+include_recipe 'ec2-tags-ohai-plugin'
+
 if server?
   include_recipe 'chef-splunk::server'
 else


### PR DESCRIPTION
Adds cookbook dependency on [ec2-tags-ohai-plugin](https://supermarket.chef.io/cookbooks/ec2-tags-ohai-plugin) to read EC2 tags as a secondary detection method for rotating Splunk secrets

Signed-off-by: Dang H. Nguyen <dang.nguyen@disney.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
In `SecretsHelper::splunk_secret_inspect`, it looks for a chef tag on instances that need to have certain Splunk secrets rotated. This change will extend that to support EC2 tagging of instances as an option.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>