### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@
 
 ### Essential Commands (strict order)
 ```bash
-berks install                   # Install dependencies (always first)
+chef install Policyfile.rb                   # Install dependencies (always first)
 cookstyle                       # Ruby/Chef linting
 yamllint .                      # YAML linting
 markdownlint-cli2 '**/*.md'     # Markdown linting
@@ -42,7 +42,7 @@ chef exec rspec                 # Unit tests (ChefSpec)
 - **Full CI Runtime:** 30+ minutes for complete matrix
 
 ### Common Issues and Solutions
-- **Always run `berks install` first** - most failures are dependency-related
+- **Always run `chef install Policyfile.rb` first** - most failures are dependency-related
 - **Docker must be running** for kitchen tests
 - **Chef Workstation required** - no workarounds, no alternatives
 - **Test data bags needed** (optional for some cookbooks) in `test/integration/data_bags/` for convergence
@@ -88,7 +88,7 @@ These instructions are validated for Sous Chefs cookbooks. **Do not search for b
 
 **Error Resolution Checklist:**
 1. Verify Chef Workstation installation
-2. Confirm `berks install` completed successfully
+2. Confirm `chef install Policyfile.rb` completed successfully
 3. Ensure Docker is running for integration tests
 4. Check for missing test data dependencies
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write
@@ -51,7 +51,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Dokken
         uses: actionshub/test-kitchen@main
         env:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.2
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Splunk Cookbook Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Manage Splunk Enterprise or Splunk Universal Forwarder
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 This cookbook manages Splunk Enterprise and Splunk Universal Forwarder.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,13 @@ Based on Splunk 10.0 vendor documentation, the following platforms are supported
 
 ### Linux x86_64 / ARM64 (AArch64)
 
-- **Ubuntu**: 22.04, 24.04
-- **Debian**: 12, 13
-- **AlmaLinux**: 9, 10
-- **Rocky Linux**: 9, 10
-- **RHEL**: 9, 10
-- **Amazon Linux**: 2023
-- **openSUSE**: Leap 16
+* **Ubuntu**: 22.04, 24.04
+* **Debian**: 12, 13
+* **AlmaLinux**: 9, 10
+* **Rocky Linux**: 9, 10
+* **RHEL**: 9, 10
+* **Amazon Linux**: 2023
+* **openSUSE**: Leap 16
 
 ## Systemd Requirement
 
@@ -33,4 +33,4 @@ This cookbook exclusively supports `systemd` init systems. Legacy `sysvinit` and
 
 ## Chef Version Requirement
 
-- **Chef Infra Client**: 16.0 or newer (required for `unified_mode` and resource partials)
+* **Chef Infra Client**: 16.0 or newer (required for `unified_mode` and resource partials)

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-# this group can be excluded by berks; for example: `berks upload --except test`
-group :test do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -10,5 +10,5 @@ cookbook 'test', path: './test/cookbooks/test'
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
 
-  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+  named_run_list recipe_name.to_sym, 'recipe[test::' + recipe_name + ']'
 end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'chef-splunk'
+
+run_list 'recipe[test::default]'
+
+cookbook 'chef-splunk', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The supported platform list follows Splunk 10.0 package availability and this co
 * Ubuntu 22.04, 24.04
 * openSUSE Leap 16
 
-See [LIMITATIONS.md](LIMITATIONS.md) for platform and architecture notes.
+See [AGENTS.md](AGENTS.md) for platform and architecture notes.
 
 ## Resources
 

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,6 @@ provisioner:
   multiple_converge: 2
   chef_license: accept
   client_rb:
-    environment: _default
     log_level: :debug
 
 verifier: inspec
@@ -22,14 +21,20 @@ platforms:
 
 suites:
   - name: default
+    provisioner:
+      named_run_list: default
     run_list:
       - recipe[test::default]
 
   - name: client
+    provisioner:
+      named_run_list: client
     run_list:
       - recipe[test::client]
 
   - name: server-runas-root
+    provisioner:
+      named_run_list: server_runas_root
     lifecycle:
       post_converge:
         - local: sleep 120
@@ -37,6 +42,8 @@ suites:
       - recipe[test::server_runas_root]
 
   - name: server-runas-splunk
+    provisioner:
+      named_run_list: server
     lifecycle:
       post_converge:
         - local: sleep 120
@@ -44,6 +51,8 @@ suites:
       - recipe[test::server]
 
   - name: server-shdeployer
+    provisioner:
+      named_run_list: server_shdeployer
     lifecycle:
       post_converge:
         - local: sleep 120
@@ -51,25 +60,37 @@ suites:
       - recipe[test::server_shdeployer]
 
   - name: disabled
+    provisioner:
+      named_run_list: disabled
     run_list:
       - recipe[test::disabled]
 
   - name: upgrade-server
+    provisioner:
+      named_run_list: upgrade_server
     run_list:
       - recipe[test::upgrade_server]
 
   - name: upgrade-client
+    provisioner:
+      named_run_list: upgrade_client
     run_list:
       - recipe[test::upgrade_client]
 
   - name: server-resources
+    provisioner:
+      named_run_list: server_resources
     run_list:
       - recipe[test::server_resources]
 
   - name: client-resources
+    provisioner:
+      named_run_list: client_resources
     run_list:
       - recipe[test::client_resources]
 
   - name: uninstall-client
+    provisioner:
+      named_run_list: uninstall_client
     run_list:
       - recipe[test::uninstall_client]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list